### PR TITLE
fix: various fixes and updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN ./gradlew --version
 
 COPY ./build.gradle ./settings.gradle /code/
 COPY ./src /code/src
+COPY ./shadow-radar-auth /code/shadow-radar-auth
 
 RUN ./gradlew unpack
 
@@ -25,6 +26,11 @@ ENV SPRING_PROFILES_ACTIVE prod
 
 VOLUME /tmp
 ARG DEPENDENCY=/code/build/dependency
+
+RUN apt-get update && apt-get install -y \
+        curl \
+        wget \
+        && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder ${DEPENDENCY}/BOOT-INF/lib /app/lib
 COPY --from=builder ${DEPENDENCY}/META-INF /app/META-INF

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.1-jdk-slim AS builder
+FROM openjdk:11-jdk-slim AS builder
 
 RUN mkdir /code
 WORKDIR /code
@@ -15,7 +15,7 @@ COPY ./shadow-radar-auth /code/shadow-radar-auth
 
 RUN ./gradlew unpack
 
-FROM openjdk:11.0.1-jre-slim
+FROM openjdk:11-jre-slim
 
 LABEL maintainer="Yatharth Ranjan <yatharth.ranjan@kcl.ac.uk>"
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ plugins {
     id "com.github.spotbugs" version "4.5.0"
     id 'jacoco'
     id "com.github.lkishalmi.gatling" version "3.3.4"
+    id 'com.github.johnrengelman.shadow' version '6.1.0'
 }
 
 apply plugin: 'java'
@@ -114,6 +115,8 @@ dependencies {
     implementation(group: 'org.radarbase', name: 'radar-spring-auth', version: radarSpringAuthVersion) {
         exclude group: 'javax.servlet', module: 'servlet-api'
     }
+
+    implementation project(path: ':shadow-radar-auth', configuration: 'shadow')
 
     codacy 'com.github.codacy:codacy-coverage-reporter:-SNAPSHOT'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'appserver'
+include 'shadow-radar-auth'

--- a/shadow-radar-auth/build.gradle
+++ b/shadow-radar-auth/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'com.github.johnrengelman.shadow'
+}
+apply plugin: 'java-library'
+
+repositories {
+    mavenCentral()
+    jcenter()
+}
+
+dependencies {
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.11.4"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.11.4"
+    implementation "commons-codec:commons-codec:1.15"
+}
+
+shadowJar {
+    relocate 'org.apache.commons.codec', 'shadow.org.apache.commons.codec'
+    relocate 'com.fasterxml.jackson', 'shadow.com.fasterxml.jackson'
+}


### PR DESCRIPTION
- Fixes class not found due to shadowing in radar-auth lib. see https://github.com/RADAR-base/ManagementPortal/pull/554.
- Add support for reading the radar_is file first instead of using default URL for public key endpoints.
- Add wget to Dockerfile for running healthchecks.