### PR TITLE
Include DTO in exception so app can read the id.

### DIFF
--- a/src/main/java/org/radarbase/appserver/controller/exception/CustomExceptionHandler.java
+++ b/src/main/java/org/radarbase/appserver/controller/exception/CustomExceptionHandler.java
@@ -23,6 +23,7 @@ package org.radarbase.appserver.controller.exception;
 
 import java.util.Map;
 import org.hibernate.exception.ConstraintViolationException;
+import org.radarbase.appserver.exception.NotificationAlreadyExistsException;
 import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -30,6 +31,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
@@ -58,5 +61,12 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
     Map<String, Object> body = DEFAULT_ERROR_ATTRIBUTES.getErrorAttributes(request, true);
     body.put("status", status);
     return handleExceptionInternal(ex, body, headers, status, request);
+  }
+
+  @ExceptionHandler(NotificationAlreadyExistsException.class)
+  @ResponseStatus(HttpStatus.CONFLICT)
+  public @ResponseBody NotificationAlreadyExistsException handleException(
+      NotificationAlreadyExistsException e) {
+    return e;
   }
 }

--- a/src/main/java/org/radarbase/appserver/exception/NotificationAlreadyExistsException.java
+++ b/src/main/java/org/radarbase/appserver/exception/NotificationAlreadyExistsException.java
@@ -1,0 +1,62 @@
+/*
+ *
+ *  *
+ *  *  * Copyright 2018 King's College London
+ *  *  *
+ *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  * you may not use this file except in compliance with the License.
+ *  *  * You may obtain a copy of the License at
+ *  *  *
+ *  *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *  *
+ *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  * See the License for the specific language governing permissions and
+ *  *  * limitations under the License.
+ *  *  *
+ *  *
+ *
+ */
+
+package org.radarbase.appserver.exception;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.NoArgsConstructor;
+import net.minidev.json.annotate.JsonIgnore;
+import org.radarbase.appserver.dto.fcm.FcmNotificationDto;
+
+/**
+ * Exception thrown when a requested {@link org.radarbase.appserver.entity.Notification} that needs
+ * to be added/created already exists.
+ *
+ * see {@link org.radarbase.appserver.controller.exception.CustomExceptionHandler}
+ * @author yatharthranjan
+ */
+@NoArgsConstructor
+@JsonIgnoreProperties({"cause", "stackTrace", "suppressed", "localizedMessage"})
+public class NotificationAlreadyExistsException extends RuntimeException {
+
+  @JsonIgnore private static final long serialVersionUID = -79364859476939L;
+
+  private String errorMessage;
+  private FcmNotificationDto dto;
+
+  public NotificationAlreadyExistsException(String message) {
+    super(message);
+  }
+
+  public NotificationAlreadyExistsException(String message, FcmNotificationDto object) {
+    super(message + " " + object.toString());
+    this.dto = object;
+    this.errorMessage = message;
+  }
+
+  public FcmNotificationDto getDto() {
+    return dto;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+}

--- a/src/main/java/org/radarbase/appserver/repository/NotificationRepository.java
+++ b/src/main/java/org/radarbase/appserver/repository/NotificationRepository.java
@@ -48,6 +48,15 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             String type,
             int ttlSeconds);
 
+    Optional<Notification> findByUserIdAndSourceIdAndScheduledTimeAndTitleAndBodyAndTypeAndTtlSeconds(
+            Long userId,
+            String sourceId,
+            Instant scheduledTime,
+            String title,
+            String body,
+            String type,
+            int ttlSeconds);
+
     boolean existsByIdAndUserId(Long id, Long userId);
 
     boolean existsById(@NotNull Long id);


### PR DESCRIPTION
- Also changes the http response code to 409 conflict when notification already exists.

Example return response -

```json
{
    "errorMessage": "The Notification Already exists. Please Use update endpoint",
    "dto": {
        "id": 3,
        "scheduledTime": 1561821958.054,
        "delivered": false,
        "title": "c",
        "body": "z",
        "ttlSeconds": 86400,
        "sourceId": "z",
        "fcmMessageId": "16006630",
        "fcmTopic": null,
        "fcmCondition": null,
        "type": "ESM",
        "appPackage": "aRMT",
        "sourceType": "aRMT",
        "additionalData": {},
        "priority": null,
        "sound": null,
        "badge": null,
        "subtitle": null,
        "icon": null,
        "color": null,
        "bodyLocKey": null,
        "bodyLocArgs": null,
        "titleLocKey": null,
        "titleLocArgs": null,
        "androidChannelId": null,
        "tag": null,
        "clickAction": null,
        "mutableContent": false,
        "createdAt": 1615551355.674,
        "updatedAt": 1615551355.674
    },
    "message": "The Notification Already exists. Please Use update endpoint FcmNotificationDto(id=3, scheduledTime=2019-06-29T15:25:58.054Z, delivered=false, title=c, body=z, ttlSeconds=86400, sourceId=z, fcmMessageId=16006630, fcmTopic=null, fcmCondition=null, type=ESM, appPackage=aRMT, sourceType=aRMT, additionalData={}, priority=null, sound=null, badge=null, subtitle=null, icon=null, color=null, bodyLocKey=null, bodyLocArgs=null, titleLocKey=null, titleLocArgs=null, androidChannelId=null, tag=null, clickAction=null, mutableContent=false, createdAt=2021-03-12T12:15:55.674Z, updatedAt=2021-03-12T12:15:55.674Z)"
}
```