### PR TITLE
Delete single notification from scheduler

### DIFF
--- a/src/main/java/org/radarbase/appserver/service/FcmNotificationService.java
+++ b/src/main/java/org/radarbase/appserver/service/FcmNotificationService.java
@@ -334,11 +334,12 @@ public class FcmNotificationService implements NotificationService {
     @Transactional
     public void deleteNotificationByProjectIdAndSubjectIdAndNotificationId(String projectId, String subjectId, Long id) {
         User user = subjectAndProjectExistElseThrow(subjectId, projectId);
+        Long userId = user.getId();
 
-        if (this.notificationRepository.existsByIdAndUserId(id, user.getId())) {
+        if (this.notificationRepository.existsByIdAndUserId(id, userId)) {
             this.schedulerService.deleteScheduled(
-                    this.notificationRepository.findByIdAndUserId(id, user.getId()).get());
-            this.notificationRepository.deleteByIdAndUserId(id, user.getId());
+                    this.notificationRepository.findByIdAndUserId(id, userId).get());
+            this.notificationRepository.deleteByIdAndUserId(id, userId);
         } else
             throw new InvalidNotificationDetailsException(
                     "Notification with the provided ID does not exist.");

--- a/src/main/java/org/radarbase/appserver/service/FcmNotificationService.java
+++ b/src/main/java/org/radarbase/appserver/service/FcmNotificationService.java
@@ -337,7 +337,7 @@ public class FcmNotificationService implements NotificationService {
 
         if (this.notificationRepository.existsByIdAndUserId(id, user.getId())) {
             this.schedulerService.deleteScheduled(
-                    this.notificationRepository.findById(id).get());
+                    this.notificationRepository.findByIdAndUserId(id, user.getId()).get());
             this.notificationRepository.deleteByIdAndUserId(id, user.getId());
         } else
             throw new InvalidNotificationDetailsException(


### PR DESCRIPTION
- Delete from scheduler as well when deleting single FCM notifications. This was causing `Notification does not exist` errors when scheduling messages that have been deleted.
- Some minor formatting fixes

Solves #238 