### PR TITLE
Move saving of questionnaire schedule tasks outside streams

### DIFF
--- a/src/main/java/org/radarbase/appserver/controller/RadarUserController.java
+++ b/src/main/java/org/radarbase/appserver/controller/RadarUserController.java
@@ -91,6 +91,8 @@ public class RadarUserController {
           null)) {
         if (forceFcmToken) this.userService.checkFcmTokenExistsAndReplace(userDto);
         FcmUserDto user = this.userService.saveUserInProject(userDto);
+        // Generate schedule for user
+        this.userService.generateSchedule(user);
         return ResponseEntity.created(
                 new URI("/" + PathsUtil.USER_PATH + "/user?id=" + user.getId()))
             .body(user);
@@ -101,6 +103,8 @@ public class RadarUserController {
     } else {
       if (forceFcmToken) this.userService.checkFcmTokenExistsAndReplace(userDto);
       FcmUserDto user = this.userService.saveUserInProject(userDto);
+      // Generate schedule for user
+      this.userService.generateSchedule(user);
       return ResponseEntity.created(new URI("/" + PathsUtil.USER_PATH + "/user?id=" + user.getId()))
           .body(user);
     }

--- a/src/main/java/org/radarbase/appserver/controller/RadarUserController.java
+++ b/src/main/java/org/radarbase/appserver/controller/RadarUserController.java
@@ -91,8 +91,6 @@ public class RadarUserController {
           null)) {
         if (forceFcmToken) this.userService.checkFcmTokenExistsAndReplace(userDto);
         FcmUserDto user = this.userService.saveUserInProject(userDto);
-        // Generate schedule for user
-        this.userService.generateSchedule(user);
         return ResponseEntity.created(
                 new URI("/" + PathsUtil.USER_PATH + "/user?id=" + user.getId()))
             .body(user);
@@ -103,8 +101,6 @@ public class RadarUserController {
     } else {
       if (forceFcmToken) this.userService.checkFcmTokenExistsAndReplace(userDto);
       FcmUserDto user = this.userService.saveUserInProject(userDto);
-      // Generate schedule for user
-      this.userService.generateSchedule(user);
       return ResponseEntity.created(new URI("/" + PathsUtil.USER_PATH + "/user?id=" + user.getId()))
           .body(user);
     }

--- a/src/main/java/org/radarbase/appserver/service/QuestionnaireScheduleService.java
+++ b/src/main/java/org/radarbase/appserver/service/QuestionnaireScheduleService.java
@@ -156,7 +156,7 @@ public class QuestionnaireScheduleService {
     private List<Task> getTasksListFromAssessmentSchedules(List<AssessmentSchedule> assessmentSchedules) {
         return assessmentSchedules.stream()
                 .filter(s -> s.hasTasks())
-                .flatMap(a -> a.getTasks().stream().filter(Objects::nonNull))
+                .flatMap(a -> a.getTasks().stream())
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/org/radarbase/appserver/service/QuestionnaireScheduleService.java
+++ b/src/main/java/org/radarbase/appserver/service/QuestionnaireScheduleService.java
@@ -21,7 +21,6 @@
 
 package org.radarbase.appserver.service;
 
-import javafx.util.Pair;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.radarbase.appserver.dto.protocol.Assessment;
@@ -34,7 +33,6 @@ import org.radarbase.appserver.entity.Task;
 import org.radarbase.appserver.entity.User;
 import org.radarbase.appserver.exception.NotFoundException;
 import org.radarbase.appserver.repository.ProjectRepository;
-import org.radarbase.appserver.repository.TaskRepository;
 import org.radarbase.appserver.repository.UserRepository;
 import org.radarbase.appserver.search.TaskSpecificationsBuilder;
 import org.radarbase.appserver.service.questionnaire.protocol.ProtocolGenerator;
@@ -71,17 +69,18 @@ public class QuestionnaireScheduleService {
 
     private final transient UserRepository userRepository;
 
-    private final transient TaskRepository taskRepository;
-
     private final transient QuestionnaireScheduleGeneratorService scheduleGeneratorService;
 
     private final transient ProjectRepository projectRepository;
 
     @Autowired
-    public QuestionnaireScheduleService(ProtocolGenerator protocolGenerator, UserRepository userRepository, ProjectRepository projectRepository, QuestionnaireScheduleGeneratorService scheduleGeneratorService, TaskRepository taskRepository) {
+    private final transient TaskService taskService;
+
+    @Autowired
+    public QuestionnaireScheduleService(ProtocolGenerator protocolGenerator, UserRepository userRepository, ProjectRepository projectRepository, QuestionnaireScheduleGeneratorService scheduleGeneratorService, TaskService taskService) {
         this.userRepository = userRepository;
         this.projectRepository = projectRepository;
-        this.taskRepository = taskRepository;
+        this.taskService = taskService;
         this.protocolGenerator = protocolGenerator;
         this.scheduleGeneratorService = scheduleGeneratorService;
     }
@@ -100,7 +99,7 @@ public class QuestionnaireScheduleService {
                                                                String search) {
 
         Specification<Task> spec = getSearchBuilder(projectId, subjectId, type, search).build();
-        return this.taskRepository.findAll(spec);
+        return this.taskService.getTasksBySpecification(spec);
 
 //        if (type != AssessmentType.ALL) {
 //            return getTasksUsingProjectIdAndSubjectId(projectId, subjectId);
@@ -122,16 +121,8 @@ public class QuestionnaireScheduleService {
     }
 
     @Transactional
-    public Task getTaskUsingProjectIdAndSubjectIdAndTaskId(String projectId, String subjectId, Long taskId) {
-        User user = subjectAndProjectExistElseThrow(subjectId, projectId);
-        return this.taskRepository.findByIdAndUserId(taskId, user.getId())
-                .orElseThrow(() -> new NotFoundException("The task was not found"));
-    }
-
-
-    @Transactional
     public List<Task> getTasksForUser(User user) {
-        return this.taskRepository.findByUserId(user.getId());
+        return this.taskService.getTasksByUser(user);
     }
 
     @Transactional
@@ -154,8 +145,19 @@ public class QuestionnaireScheduleService {
             this.removeScheduleForUser(user);
         }
         Schedule newSchedule = this.scheduleGeneratorService.generateScheduleForUser(user, protocol, prevSchedule);
+
+        List<Task> tasks = getTasksListFromAssessmentSchedules(newSchedule.getAssessmentSchedules());
+        this.taskService.addTasks(tasks, user);
+
         subjectScheduleMap.put(user.getSubjectId(), newSchedule);
         return newSchedule;
+    }
+
+    private List<Task> getTasksListFromAssessmentSchedules(List<AssessmentSchedule> assessmentSchedules) {
+        return assessmentSchedules.stream()
+                .filter(s -> s.hasTasks())
+                .flatMap(a -> a.getTasks().stream().filter(Objects::nonNull))
+                .collect(Collectors.toList());
     }
 
     @Transactional
@@ -205,13 +207,12 @@ public class QuestionnaireScheduleService {
         Specification<Task> spec = getSearchBuilder(projectId, subjectId, type, search).build();
 
         // TODO: DeleteAll with Specifications will soon be released in JPA (v 3.0.0), so update this to not fetch all entities.
-        List<Task> tasks = taskRepository.findAll(spec);
-        taskRepository.deleteAll(tasks);
+        this.taskService.deleteTasksBySpecification(spec);
     }
 
     @Transactional
     public void removeScheduleForUser(User user) {
-        this.taskRepository.deleteByUserId(user.getId());
+        this.taskService.deleteTasksByUserId(user.getId());
     }
 
     public User subjectAndProjectExistElseThrow(String subjectId, String projectId) {

--- a/src/main/java/org/radarbase/appserver/service/TaskService.java
+++ b/src/main/java/org/radarbase/appserver/service/TaskService.java
@@ -118,6 +118,11 @@ public class TaskService {
     }
 
     @Transactional
+    public void deleteTasksByUserId(Long userId) {
+        taskRepository.deleteByUserId(userId);
+    }
+
+    @Transactional
     public Task addTask(Task task) {
         User user = task.getUser();
         if (!this.taskRepository.existsByUserIdAndNameAndTimestamp(user.getId(), task.getName(), task.getTimestamp())) {

--- a/src/main/java/org/radarbase/appserver/service/TaskStateEventService.java
+++ b/src/main/java/org/radarbase/appserver/service/TaskStateEventService.java
@@ -58,7 +58,6 @@ public class TaskStateEventService {
     private final transient TaskStateEventRepository taskStateEventRepository;
     private final transient TaskService taskService;
 
-    private final transient QuestionnaireScheduleService scheduleService;
     private final transient ApplicationEventPublisher taskApplicationEventPublisher;
     private final transient ObjectMapper objectMapper;
 
@@ -66,12 +65,10 @@ public class TaskStateEventService {
     public TaskStateEventService(
             TaskStateEventRepository taskStateEventRepository,
             TaskService taskService,
-            QuestionnaireScheduleService scheduleService,
             ApplicationEventPublisher taskApplicationEventPublisher,
             ObjectMapper objectMapper) {
         this.taskStateEventRepository = taskStateEventRepository;
         this.taskService = taskService;
-        this.scheduleService = scheduleService;
         this.taskApplicationEventPublisher = taskApplicationEventPublisher;
         this.objectMapper = objectMapper;
     }
@@ -85,8 +82,7 @@ public class TaskStateEventService {
     @Transactional(readOnly = true)
     public List<TaskStateEventDto> getTaskStateEvents(
             String projectId, String subjectId, long taskId) {
-        Task task = scheduleService.getTaskUsingProjectIdAndSubjectIdAndTaskId(
-                projectId, subjectId, taskId);
+        Task task = taskService.getTaskById(taskId);
         List<TaskStateEvent> stateEvents =
                 taskStateEventRepository.findByTaskId(taskId);
         return stateEvents.stream()
@@ -127,7 +123,7 @@ public class TaskStateEventService {
             throws SizeLimitExceededException {
 
         checkState(taskId, taskStateEventDto.getState());
-        Task task = scheduleService.getTaskUsingProjectIdAndSubjectIdAndTaskId(projectId, subjectId, taskId);
+        Task task = this.taskService.getTaskById(taskId);
 
         Map<String, String> additionalInfo = null;
         if (!taskStateEventDto.getAssociatedInfo().isEmpty()) {

--- a/src/main/java/org/radarbase/appserver/service/UserService.java
+++ b/src/main/java/org/radarbase/appserver/service/UserService.java
@@ -156,11 +156,9 @@ public class UserService {
     // maintain a bi-directional relationship
     newUser.getUsermetrics().setUser(newUser);
     User savedUser = this.userRepository.saveAndFlush(newUser);
+    // Generate schedule for user
+    this.scheduleService.generateScheduleForUser(savedUser);
     return userConverter.entityToDto(savedUser);
-  }
-
-  public Schedule generateSchedule(FcmUserDto user) {
-    return this.scheduleService.generateScheduleUsingProjectIdAndSubjectId(user.getProjectId(), user.getSubjectId());
   }
 
   // TODO update to use Id instead of subjectId

--- a/src/main/java/org/radarbase/appserver/service/UserService.java
+++ b/src/main/java/org/radarbase/appserver/service/UserService.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.radarbase.appserver.converter.UserConverter;
 import org.radarbase.appserver.dto.fcm.FcmUserDto;
 import org.radarbase.appserver.dto.fcm.FcmUsers;
+import org.radarbase.appserver.dto.questionnaire.Schedule;
 import org.radarbase.appserver.entity.Project;
 import org.radarbase.appserver.entity.User;
 import org.radarbase.appserver.exception.InvalidUserDetailsException;
@@ -155,9 +156,11 @@ public class UserService {
     // maintain a bi-directional relationship
     newUser.getUsermetrics().setUser(newUser);
     User savedUser = this.userRepository.saveAndFlush(newUser);
-    // Generate schedule for user
-    this.scheduleService.generateScheduleForUser(savedUser);
     return userConverter.entityToDto(savedUser);
+  }
+
+  public Schedule generateSchedule(FcmUserDto user) {
+    return this.scheduleService.generateScheduleUsingProjectIdAndSubjectId(user.getProjectId(), user.getSubjectId());
   }
 
   // TODO update to use Id instead of subjectId

--- a/src/main/java/org/radarbase/appserver/service/questionnaire/protocol/ClinicalProtocolHandler.java
+++ b/src/main/java/org/radarbase/appserver/service/questionnaire/protocol/ClinicalProtocolHandler.java
@@ -33,6 +33,7 @@ public class ClinicalProtocolHandler implements ProtocolHandler {
 
     @Override
     public AssessmentSchedule handle(AssessmentSchedule assessmentSchedule, Assessment assessment, User user) {
+        assessmentSchedule.setName(assessment.getName());
         return assessmentSchedule;
     }
 

--- a/src/main/java/org/radarbase/appserver/service/questionnaire/protocol/SimpleRepeatQuestionnaireHandler.java
+++ b/src/main/java/org/radarbase/appserver/service/questionnaire/protocol/SimpleRepeatQuestionnaireHandler.java
@@ -73,10 +73,7 @@ public class SimpleRepeatQuestionnaireHandler implements ProtocolHandler {
                     return t.stream();
                 }).collect(Collectors.toList());
 
-        this.taskService.addTasks(tasks, user);
-        List<Task> allTasks = this.taskService.getTasksByUser(user);
-
-        return allTasks;
+        return tasks;
     }
 
     private Long calculateCompletionWindow(TimePeriod completionWindow) {


### PR DESCRIPTION
- How questionnaire schedule generation works is that for each assessment in the protocol, parallel streams are used to generate tasks. Previously, within each stream, the tasks are saved in the database. However, there are issues when the schedule generation occurs right after changes in the database are made (e.g. User entity creation/changes). The db changes are not seen by the thread that's generating the tasks because the code in the threads will not be a part of the original transaction (where the db changes occurred).
- This solves the issue by moving the saving of the tasks outside the parallel streams (after all tasks are generated, as opposed to saving them as they are generated).