### PR TITLE
Cache questionnaires and standardize github client access

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,16 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
+    - uses: actions/setup-java@v3
+      if: matrix.language == 'java'
+      with:
+        java-version: 17
+        distribution: temurin
+
+    - uses: gradle/gradle-build-action@v2
+      if: matrix.language == 'java'
+
+      # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ bin/
 docker/prod
 
 *__pycache__
+google-credentials.json

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -96,3 +96,9 @@ security.radar.managementportal.url=http://localhost:8081
 
 # Github Authentication
 security.github.client.token=
+security.github.client.timeout=10
+# max content size 1 MB
+security.github.client.maxContentLength=1000000
+security.github.cache.size=10000
+security.github.cache.duration=3600
+security.github.cache.retryDuration=60

--- a/src/integrationTest/resources/docker/docker-compose.yml
+++ b/src/integrationTest/resources/docker/docker-compose.yml
@@ -64,7 +64,7 @@ services:
   # Management Portal                                                         #
   #---------------------------------------------------------------------------#
   managementportal:
-    image: radarbase/management-portal:0.5.6
+    image: radarbase/management-portal:2.0.0
     ports:
       - "8081:8081"
     environment:

--- a/src/main/java/org/radarbase/appserver/controller/GithubEndpoint.java
+++ b/src/main/java/org/radarbase/appserver/controller/GithubEndpoint.java
@@ -22,7 +22,7 @@
 package org.radarbase.appserver.controller;
 
 import org.radarbase.appserver.config.AuthConfig;
-import org.radarbase.appserver.service.GithubClient;
+import org.radarbase.appserver.service.GithubService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -31,17 +31,16 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import radar.spring.auth.common.Authorized;
 
-import java.io.IOException;
 import java.net.MalformedURLException;
 
 @RestController
 public class GithubEndpoint {
 
-    private transient GithubClient githubClient;
+    private final transient GithubService githubService;
 
     @Autowired
-    public GithubEndpoint(GithubClient githubClient) {
-        this.githubClient = githubClient;
+    public GithubEndpoint(GithubService githubService) {
+        this.githubService = githubService;
     }
 
     @Authorized(
@@ -51,13 +50,13 @@ public class GithubEndpoint {
             PathsUtil.GITHUB_PATH
             + "/" +
             PathsUtil.GITHUB_CONTENT_PATH)
-    public ResponseEntity getGithubContent(@RequestParam() String url
+    public ResponseEntity<String> getGithubContent(@RequestParam() String url
     ) {
         try {
-            return ResponseEntity.ok().body(this.githubClient.getGithubContent(url));
+            return ResponseEntity.ok().body(this.githubService.getGithubContent(url));
         } catch (MalformedURLException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
-        } catch (IOException | InterruptedException e) {
+        } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body("Error getting content from Github.");
         }
     }

--- a/src/main/java/org/radarbase/appserver/entity/User.java
+++ b/src/main/java/org/radarbase/appserver/entity/User.java
@@ -22,22 +22,35 @@
 package org.radarbase.appserver.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
-import java.io.Serializable;
-import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-
 import lombok.Getter;
 import lombok.ToString;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.radarbase.appserver.dto.fcm.FcmUserDto;
 import org.springframework.lang.Nullable;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * {@link Entity} for persisting users. The corresponding DTO is {@link FcmUserDto}. A {@link
@@ -97,7 +110,7 @@ public class User extends AuditModel implements Serializable {
     @CollectionTable(name = "attributes_map")
     @MapKeyColumn(name = "key", nullable = true)
     @Column(name = "value")
-    private Map<String, String> attributes = new HashMap<String, String>();
+    private Map<String, String> attributes = new HashMap<>();
 
     public User setSubjectId(String subjectId) {
         this.subjectId = subjectId;

--- a/src/main/java/org/radarbase/appserver/service/GithubClient.java
+++ b/src/main/java/org/radarbase/appserver/service/GithubClient.java
@@ -39,6 +39,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Optional;
 
 @Slf4j
 @Component
@@ -48,8 +49,7 @@ public class GithubClient {
     private static final String GITHUB_API_ACCEPT_HEADER = "application/vnd.github.v3+json";
     private final transient HttpClient client;
 
-    @Value("${security.github.client.token}")
-    private transient String githubToken;
+    private final transient String githubToken;
 
     private transient final Duration httpTimeout;
 
@@ -59,7 +59,9 @@ public class GithubClient {
     @SneakyThrows
     @Autowired
     public GithubClient(
-            @Value("${security.github.client.timeout:10}") int httpTimeout) {
+            @Value("${security.github.client.timeout:10}") int httpTimeout,
+            @Value("${security.github.client.token:}") String githubToken) {
+        this.githubToken = githubToken != null && !githubToken.isBlank() ? githubToken.trim() : null;
         this.httpTimeout = Duration.ofSeconds(httpTimeout);
         client = HttpClient.newBuilder()
                 .followRedirects(HttpClient.Redirect.NORMAL)
@@ -128,7 +130,7 @@ public class GithubClient {
                 .header("Accept", GITHUB_API_ACCEPT_HEADER)
                 .GET()
                 .timeout(httpTimeout);
-        if (githubToken != null && !githubToken.isEmpty()) {
+        if (githubToken != null) {
             request.header("Authorization", "Bearer " + githubToken);
         }
         return request.build();

--- a/src/main/java/org/radarbase/appserver/service/GithubService.java
+++ b/src/main/java/org/radarbase/appserver/service/GithubService.java
@@ -1,0 +1,33 @@
+package org.radarbase.appserver.service;
+
+import org.radarbase.appserver.util.FunctionCache;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@Scope(value = ConfigurableBeanFactory.SCOPE_SINGLETON)
+public class GithubService {
+
+    private final transient FunctionCache<String, String> cache;
+
+    @Autowired
+    public GithubService(
+            GithubClient githubClient,
+            @Value("${security.github.service.cacheDuration:PT1H}")
+            Duration cacheTime,
+            @Value("${security.github.service.retryDuration:PT1M}")
+            Duration retryTime,
+            @Value("${security.github.service.cacheSize:10000}")
+            int maxSize) {
+        this.cache = new FunctionCache<>(githubClient::getGithubContent, cacheTime, retryTime, maxSize);
+    }
+
+    public String getGithubContent(String url) throws Exception {
+        return this.cache.getOrThrow(url);
+    }
+}

--- a/src/main/java/org/radarbase/appserver/service/GithubService.java
+++ b/src/main/java/org/radarbase/appserver/service/GithubService.java
@@ -1,6 +1,6 @@
 package org.radarbase.appserver.service;
 
-import org.radarbase.appserver.util.FunctionCache;
+import org.radarbase.appserver.util.CachedFunction;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -13,7 +13,7 @@ import java.time.Duration;
 @Scope(value = ConfigurableBeanFactory.SCOPE_SINGLETON)
 public class GithubService {
 
-    private final transient FunctionCache<String, String> cache;
+    private final transient CachedFunction<String, String> cachedGetContent;
 
     @Autowired
     public GithubService(
@@ -24,10 +24,10 @@ public class GithubService {
             Duration retryTime,
             @Value("${security.github.cache.size:10000}")
             int maxSize) {
-        this.cache = new FunctionCache<>(githubClient::getGithubContent, cacheTime, retryTime, maxSize);
+        this.cachedGetContent = new CachedFunction<>(githubClient::getGithubContent, cacheTime, retryTime, maxSize);
     }
 
     public String getGithubContent(String url) throws Exception {
-        return this.cache.getOrThrow(url);
+        return this.cachedGetContent.applyWithException(url);
     }
 }

--- a/src/main/java/org/radarbase/appserver/service/GithubService.java
+++ b/src/main/java/org/radarbase/appserver/service/GithubService.java
@@ -18,13 +18,16 @@ public class GithubService {
     @Autowired
     public GithubService(
             GithubClient githubClient,
-            @Value("${security.github.cache.duration:PT1H}")
-            Duration cacheTime,
-            @Value("${security.github.cache.retryDuration:PT1M}")
-            Duration retryTime,
+            @Value("${security.github.cache.duration:3600}")
+            int cacheTime,
+            @Value("${security.github.cache.retryDuration:60}")
+            int retryTime,
             @Value("${security.github.cache.size:10000}")
             int maxSize) {
-        this.cachedGetContent = new CachedFunction<>(githubClient::getGithubContent, cacheTime, retryTime, maxSize);
+        this.cachedGetContent = new CachedFunction<>(githubClient::getGithubContent,
+                Duration.ofSeconds(cacheTime),
+                Duration.ofSeconds(retryTime),
+                maxSize);
     }
 
     public String getGithubContent(String url) throws Exception {

--- a/src/main/java/org/radarbase/appserver/service/GithubService.java
+++ b/src/main/java/org/radarbase/appserver/service/GithubService.java
@@ -18,11 +18,11 @@ public class GithubService {
     @Autowired
     public GithubService(
             GithubClient githubClient,
-            @Value("${security.github.service.cacheDuration:PT1H}")
+            @Value("${security.github.cache.duration:PT1H}")
             Duration cacheTime,
-            @Value("${security.github.service.retryDuration:PT1M}")
+            @Value("${security.github.cache.retryDuration:PT1M}")
             Duration retryTime,
-            @Value("${security.github.service.cacheSize:10000}")
+            @Value("${security.github.cache.size:10000}")
             int maxSize) {
         this.cache = new FunctionCache<>(githubClient::getGithubContent, cacheTime, retryTime, maxSize);
     }

--- a/src/main/java/org/radarbase/appserver/service/questionnaire/protocol/DefaultProtocolGenerator.java
+++ b/src/main/java/org/radarbase/appserver/service/questionnaire/protocol/DefaultProtocolGenerator.java
@@ -21,21 +21,19 @@
 
 package org.radarbase.appserver.service.questionnaire.protocol;
 
-import java.io.IOException;
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.radarbase.appserver.dto.protocol.Protocol;
-import org.radarbase.appserver.entity.User;
 import org.radarbase.appserver.util.CachedMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 /**
  * @author yatharthranjan
@@ -90,7 +88,7 @@ public class DefaultProtocolGenerator implements ProtocolGenerator {
             return cachedProjectProtocolMap.get(projectId);
         } catch (IOException ex) {
             log.warn(
-                    "Cannot retrieve Protocols for project {} : {}, Using cached values.", projectId, ex);
+                    "Cannot retrieve Protocols for project {} : {}, Using cached values.", projectId, ex.toString());
             return cachedProjectProtocolMap.get(true).get(projectId);
         }
     }
@@ -115,7 +113,7 @@ public class DefaultProtocolGenerator implements ProtocolGenerator {
             return protocol;
         } catch (IOException ex) {
             log.warn(
-                    "Cannot retrieve Protocols for subject {} : {}, Using cached values.", subjectId, ex);
+                    "Cannot retrieve Protocols for subject {} : {}, Using cached values.", subjectId, ex.toString());
             return cachedProtocolMap.getCache().get(subjectId);
         } catch(NoSuchElementException ex) {
             log.warn("Subject does not exist in map. Fetching..");

--- a/src/main/java/org/radarbase/appserver/service/questionnaire/protocol/GithubProtocolFetcherStrategy.java
+++ b/src/main/java/org/radarbase/appserver/service/questionnaire/protocol/GithubProtocolFetcherStrategy.java
@@ -95,7 +95,7 @@ public class GithubProtocolFetcherStrategy implements ProtocolFetcherStrategy {
         this.protocolFileName = protocolFileName;
         this.protocolBranch = protocolBranch;
         projectProtocolUriMap =
-                new CachedMap<>(this::getProtocolDirectories, Duration.ofHours(3), Duration.ofHours(4));
+                new CachedMap<>(this::getProtocolDirectories, Duration.ofHours(3), Duration.ofMinutes(4));
         this.objectMapper = objectMapper;
         this.localMapper = this.objectMapper.copy();
         this.localMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/src/main/java/org/radarbase/appserver/service/questionnaire/protocol/GithubProtocolFetcherStrategy.java
+++ b/src/main/java/org/radarbase/appserver/service/questionnaire/protocol/GithubProtocolFetcherStrategy.java
@@ -25,16 +25,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.time.Duration;
-import java.util.*;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Maps;
 import lombok.SneakyThrows;
@@ -43,7 +33,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.radarbase.appserver.dto.protocol.GithubContent;
 import org.radarbase.appserver.dto.protocol.Protocol;
 import org.radarbase.appserver.dto.protocol.ProtocolCacheEntry;
-import org.radarbase.appserver.entity.Project;
 import org.radarbase.appserver.entity.User;
 import org.radarbase.appserver.repository.ProjectRepository;
 import org.radarbase.appserver.repository.UserRepository;
@@ -53,9 +42,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -66,7 +65,6 @@ public class GithubProtocolFetcherStrategy implements ProtocolFetcherStrategy {
     private final transient ProjectRepository projectRepository;
 
     private static final String GITHUB_API_URI = "https://api.github.com/repos/";
-    private static final String GITHUB_API_ACCEPT_HEADER = "application/vnd.github.v3+json";
     private final transient String protocolRepo;
     private final transient String protocolFileName;
     private final transient String protocolBranch;
@@ -74,12 +72,7 @@ public class GithubProtocolFetcherStrategy implements ProtocolFetcherStrategy {
     private final transient ObjectMapper localMapper;
     // Keeps a cache of github URI's associated with protocol for each project
     private final transient CachedMap<String, URI> projectProtocolUriMap;
-    private final transient HttpClient client;
-
     private final transient GithubClient githubClient;
-
-    @Value("${security.github.client.token}")
-    private transient String githubToken;
 
     @SneakyThrows
     @Autowired
@@ -106,98 +99,94 @@ public class GithubProtocolFetcherStrategy implements ProtocolFetcherStrategy {
         this.objectMapper = objectMapper;
         this.localMapper = this.objectMapper.copy();
         this.localMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
         this.userRepository = userRepository;
         this.projectRepository = projectRepository;
         this.githubClient = githubClient;
     }
 
-    private static boolean isSuccessfulResponse(HttpResponse response) {
-        return response.statusCode() >= 200 && response.statusCode() < 300;
-    }
-
     @Override
-    public synchronized Map<String, Protocol> fetchProtocols() throws IOException {
-        Map<String, Protocol> subjectProtocolMap = new HashMap<>();
+    public synchronized Map<String, Protocol> fetchProtocols() {
         List<User> users = this.userRepository.findAll();
 
-        Map<String, URI> protocolUriMap;
-        try {
-            protocolUriMap = projectProtocolUriMap.get();
-        } catch (IOException e) {
-            // Failed to get the Uri Map. try using the cached value
-            protocolUriMap = projectProtocolUriMap.getCache();
+        Set<String> protocolPaths = getProtocolPaths();
+        if (protocolPaths == null) {
+            return Map.of();
         }
 
-        if (protocolUriMap == null) {
-            return subjectProtocolMap;
-        }
-
-        Set<String> protocolPaths = protocolUriMap.keySet();
-        subjectProtocolMap = users.parallelStream()
-                .map(u -> {
-                    ProtocolCacheEntry entry = this.fetchProtocolForSingleUser(u, u.getProject().getProjectId(), protocolPaths);
-                    return entry;
-                })
+        Map<String, Protocol> subjectProtocolMap = users.parallelStream()
+                .map(u -> this.fetchProtocolForSingleUser(u, u.getProject().getProjectId(), protocolPaths))
                 .filter(c -> c.getProtocol() != null)
-                .collect(Collectors.toMap(p -> p.getId(), p -> p.getProtocol()));
+                .collect(Collectors.toMap(ProtocolCacheEntry::getId, ProtocolCacheEntry::getProtocol));
 
         log.info("Refreshed Protocols from Github");
         return subjectProtocolMap;
     }
 
     private ProtocolCacheEntry fetchProtocolForSingleUser(User u, String projectId, Set<String> protocolPaths) {
-        Map<String, String> attributes = u.getAttributes();
-        Map<String, String> pathMap = protocolPaths.stream().filter(k -> k.contains(projectId))
+        Map<String, String> attributes = u.getAttributes() != null ? u.getAttributes() : Map.of();
+        Map<String, String> pathMap = protocolPaths.stream()
+                .filter(k -> k.contains(projectId))
                 .map(p -> {
                     Map<String, String> path = this.convertPathToAttributeMap(p, projectId);
                     return Maps.difference(attributes, path).entriesInCommon();
-                }).max(Comparator.comparingInt(Map::size)).orElse(Collections.emptyMap());
+                })
+                .max(Comparator.comparingInt(Map::size))
+                .orElse(Collections.emptyMap());
+
         try {
             String attributePath = this.convertAttributeMapToPath(pathMap, projectId);
             if (projectProtocolUriMap.get().containsKey(attributePath)) {
                 URI uri = projectProtocolUriMap.get(attributePath);
                 return new ProtocolCacheEntry(u.getSubjectId(), getProtocolFromUrl(uri));
+            } else {
+                return new ProtocolCacheEntry(u.getSubjectId(), null);
             }
-            return new ProtocolCacheEntry(u.getSubjectId(), null);
         } catch (IOException | InterruptedException | ResponseStatusException e) {
             return new ProtocolCacheEntry(u.getSubjectId(), null);
         }
     }
 
     @Override
-    public synchronized Map<String, Protocol> fetchProtocolsPerProject() throws IOException {
-        Map<String, Protocol> projectProtocolMap = new HashMap<>();
-        List<Project> projects = this.projectRepository.findAll();
+    public synchronized Map<String, Protocol> fetchProtocolsPerProject() {
+        Set<String> protocolPaths = getProtocolPaths();
 
-        Map<String, URI> protocolUriMap;
-        try {
-            protocolUriMap = projectProtocolUriMap.get();
-        } catch (IOException e) {
-            // Failed to get the Uri Map. try using the cached value
-            protocolUriMap = projectProtocolUriMap.getCache();
+        if (protocolPaths == null) {
+            return Map.of();
         }
 
-        if (protocolUriMap == null) {
-            return projectProtocolMap;
-        }
-
-        Set<String> protocolPaths = protocolUriMap.keySet();
-        projectProtocolMap = projects.parallelStream()
+        Map<String, Protocol> projectProtocolMap = projectRepository.findAll()
+                .parallelStream()
                 .map(project -> {
                     String projectId = project.getProjectId();
-                    String path = protocolPaths.stream().filter(k -> k.contains(projectId)).findFirst().get();
-                    try {
-                        URI uri = projectProtocolUriMap.get(path);
-                        Protocol protocol = getProtocolFromUrl(uri);
-                        return new ProtocolCacheEntry(projectId, protocol);
-                    } catch (IOException | InterruptedException | ResponseStatusException e) {
-                        return new ProtocolCacheEntry(projectId, null);
-                    }
-                }).collect(Collectors.toMap(p -> p.getId(), p -> p.getProtocol()));
+                    Protocol protocol = protocolPaths.stream()
+                            .filter(k -> k.contains(projectId))
+                            .findFirst()
+                            .map(path -> {
+                                try {
+                                    URI uri = projectProtocolUriMap.get(path);
+                                    return getProtocolFromUrl(uri);
+                                } catch (IOException | InterruptedException
+                                         | ResponseStatusException e) {
+                                    return null;
+                                }
+                            }).orElse(null);
+                    return new ProtocolCacheEntry(projectId, protocol);
+                })
+                .collect(Collectors.toMap(ProtocolCacheEntry::getId, ProtocolCacheEntry::getProtocol));
 
         log.info("Refreshed Protocols from Github");
         return projectProtocolMap;
+    }
+
+    private Set<String> getProtocolPaths() {
+        Map<String, URI> uriMap;
+        try {
+            uriMap = projectProtocolUriMap.get();
+        } catch (IOException e) {
+            // Failed to get the Uri Map. try using the cached value
+            uriMap = projectProtocolUriMap.getCache();
+        }
+        return uriMap != null ? uriMap.keySet() : null;
     }
 
     public Map<String, String> convertPathToAttributeMap(String path, String projectId) {
@@ -232,36 +221,20 @@ public class GithubProtocolFetcherStrategy implements ProtocolFetcherStrategy {
         Map<String, URI> protocolUriMap = new HashMap<>();
 
         try {
-            HttpResponse response =
-                    client.send(
-                            getRequest(
-                                    URI.create(GITHUB_API_URI + protocolRepo + "/branches/" + protocolBranch)),
-                            HttpResponse.BodyHandlers.ofString());
-            if (isSuccessfulResponse(response)) {
-                ObjectNode result = getArrayNode(response.body().toString());
-                String treeSha = result.findValue("tree").findValue("sha").asText();
-                URI treeUri = URI.create(GITHUB_API_URI + protocolRepo + "/git/trees/" + treeSha + "?recursive=true");
-                HttpResponse treeResponse = client.send(getRequest(treeUri), HttpResponse.BodyHandlers.ofString());
+            String content = githubClient.getGithubContent(GITHUB_API_URI + protocolRepo + "/branches/" + protocolBranch);
+            ObjectNode result = getArrayNode(content);
+            String treeSha = result.findValue("tree").findValue("sha").asText();
+            String treeContent = githubClient.getGithubContent(GITHUB_API_URI + protocolRepo + "/git/trees/" + treeSha + "?recursive=true");
 
-               if (isSuccessfulResponse(treeResponse)) {
-                   JsonNode tree = getArrayNode(treeResponse.body().toString()).get("tree");
-                   for (JsonNode jsonNode : tree) {
-                      String path = jsonNode.get("path").asText();
-                      if (path.contains(this.protocolFileName)) {
-                          protocolUriMap.put(
-                                  path,
-                                  URI.create(jsonNode.get("url").asText()));
-                   }
-                   }
-               }
+            JsonNode tree = getArrayNode(treeContent).get("tree");
+            for (JsonNode jsonNode : tree) {
+                String path = jsonNode.get("path").asText();
+                if (path.contains(this.protocolFileName)) {
+                    protocolUriMap.put(
+                            path,
+                            URI.create(jsonNode.get("url").asText()));
+                }
             }
-          else {
-                log.warn("Failed to retrieve protocols URIs from github: {}.", response);
-                throw new ResponseStatusException(
-                        HttpStatus.valueOf(response.statusCode()),
-                        "Failed to retrieve protocols URIs from github.");
-            }
-
         } catch (InterruptedException | ResponseStatusException e) {
             throw new IOException("Failed to retrieve protocols URIs from github", e);
         }
@@ -269,25 +242,15 @@ public class GithubProtocolFetcherStrategy implements ProtocolFetcherStrategy {
     }
 
     private Protocol getProtocolFromUrl(URI uri) throws IOException, InterruptedException {
-        String contentString = this.githubClient.getGithubContent(uri.toString());
+        String contentString = githubClient.getGithubContent(uri.toString());
         GithubContent content = localMapper.readValue(contentString, GithubContent.class);
         return localMapper.readValue(content.getContent(), Protocol.class);
-    }
-
-    private HttpRequest getRequest(URI uri) {
-        HttpRequest.Builder request = HttpRequest.newBuilder(uri)
-                .header("Accept", GITHUB_API_ACCEPT_HEADER)
-                .header("Authorization", "Bearer " + this.githubToken)
-                .GET()
-                .timeout(Duration.ofSeconds(10));
-
-        return request.build();
     }
 
     @SneakyThrows
     private ObjectNode getArrayNode(String json) {
         try (JsonParser parserProtocol = objectMapper.getFactory().createParser(json)) {
             return objectMapper.readTree(parserProtocol);
-          }
+        }
     }
 }

--- a/src/main/java/org/radarbase/appserver/util/CachedFunction.java
+++ b/src/main/java/org/radarbase/appserver/util/CachedFunction.java
@@ -11,14 +11,14 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class CachedFunction<K, V> implements ThrowingFunction<K, V> {
-    private final Duration cacheTime;
+    private transient final Duration cacheTime;
 
-    private final Duration retryTime;
+    private transient final Duration retryTime;
 
-    private final int maxSize;
+    private transient final int maxSize;
 
-    private final Map<K, SoftReference<Result<V>>> cachedMap;
-    private final ThrowingFunction<K, V> function;
+    private transient final Map<K, SoftReference<Result<V>>> cachedMap;
+    private transient final ThrowingFunction<K, V> function;
 
     public CachedFunction(ThrowingFunction<K, V> function,
             Duration cacheTime,
@@ -60,6 +60,7 @@ public class CachedFunction<K, V> implements ThrowingFunction<K, V> {
         }
     }
 
+    @SuppressWarnings("PMD.DataflowAnomalyAnalysis")
     private void putCache(K input, Result<V> result) {
         synchronized (cachedMap) {
             cachedMap.put(input, new SoftReference<>(result));
@@ -69,17 +70,16 @@ public class CachedFunction<K, V> implements ThrowingFunction<K, V> {
                 for (int i = 0; i < toRemove; i++) {
                     iter.next();
                     iter.remove();
-                    toRemove--;
                 }
             }
         }
     }
 
     private static class Result<T> {
-        private final Instant expiration;
-        private final T value;
+        private transient final Instant expiration;
+        private transient final T value;
 
-        private final Exception exception;
+        private transient final Exception exception;
 
         Result(Duration expiryDuration, T value, Exception exception) {
             expiration = Instant.now().plus(expiryDuration);

--- a/src/main/java/org/radarbase/appserver/util/FunctionCache.java
+++ b/src/main/java/org/radarbase/appserver/util/FunctionCache.java
@@ -1,0 +1,104 @@
+package org.radarbase.appserver.util;
+
+import org.springframework.util.function.ThrowingFunction;
+
+import java.lang.ref.SoftReference;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class FunctionCache<K, V> {
+    private final Duration cacheTime;
+
+    private final Duration retryTime;
+
+    private final int maxSize;
+
+    private final Map<K, SoftReference<Result<V>>> cachedMap;
+    private final ThrowingFunction<K, V> function;
+
+    public FunctionCache(ThrowingFunction<K, V> function,
+            Duration cacheTime,
+            Duration retryTime,
+            int maxSize) {
+        this.cacheTime = cacheTime;
+        this.retryTime = retryTime;
+        this.maxSize = maxSize;
+        this.cachedMap = new LinkedHashMap<>(16, 0.75f, false);
+        this.function = function;
+    }
+
+    public V getOrThrow(K input) throws Exception {
+        SoftReference<Result<V>> localRef;
+        synchronized (cachedMap) {
+            localRef = cachedMap.get(input);
+        }
+        Result<V> result = localRef != null ? localRef.get() : null;
+        if (result != null && result.isValid()) {
+            return result.getOrThrow();
+        }
+
+        try {
+            V content = function.applyWithException(input);
+            putCache(input, new Result<>(cacheTime, content, null));
+            return content;
+        } catch (Exception ex) {
+            synchronized (cachedMap) {
+                SoftReference<Result<V>> exRef = cachedMap.get(input);
+                Result<V> exResult = exRef != null ? exRef.get() : null;
+                if (exResult == null || exResult.isBadResult()) {
+                    putCache(input, new Result<>(retryTime, null, ex));
+                    throw ex;
+                } else {
+                    return exResult.getOrThrow();
+                }
+            }
+        }
+    }
+
+    private void putCache(K input, Result<V> result) {
+        synchronized (cachedMap) {
+            cachedMap.put(input, new SoftReference<>(result));
+            int toRemove = cachedMap.size() - maxSize;
+            if (toRemove > 0) {
+                Iterator<?> iter = cachedMap.entrySet().iterator();
+                for (int i = 0; i < toRemove; i++) {
+                    iter.next();
+                    iter.remove();
+                    toRemove--;
+                }
+            }
+        }
+    }
+
+    private static class Result<T> {
+        private final Instant expiration;
+        private final T value;
+
+        private final Exception exception;
+
+        Result(Duration expiryDuration, T value, Exception exception) {
+            expiration = Instant.now().plus(expiryDuration);
+            this.value = value;
+            this.exception = exception;
+        }
+
+        T getOrThrow() throws Exception {
+            if (exception != null) {
+                throw exception;
+            } else {
+                return value;
+            }
+        }
+
+        boolean isBadResult() {
+            return exception != null || !isValid();
+        }
+
+        boolean isValid() {
+            return Instant.now().isBefore(expiration);
+        }
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -104,5 +104,5 @@ security.github.client.timeout=PT10s
 # max content size 1 MB
 security.github.client.maxContentLength=1000000
 security.github.cache.size=10000
-security.github.cache.duration=PT1H
-security.github.cache.retryDuration=PT1M
+security.github.cache.duration=3600
+security.github.cache.retryDuration=60

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -100,3 +100,9 @@ security.radar.managementportal.url=http://localhost:8081
 #security.oauth2.client.userAuthorizationUri=
 # Github Authentication
 security.github.client.token=
+security.github.client.timeout=PT10s
+# max content size 1 MB
+security.github.client.maxContentLength=1000000
+security.github.cache.size=10000
+security.github.cache.duration=PT1H
+security.github.cache.retryDuration=PT1M

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -70,9 +70,9 @@ radar.admin.user=radar
 radar.admin.password=radar
 # Github Authentication
 security.github.client.token=
-security.github.client.timeout=PT10s
+security.github.client.timeout=10
 # max content size 1 MB
 security.github.client.maxContentLength=1000000
 security.github.cache.size=10000
-security.github.cache.duration=PT1H
-security.github.cache.retryDuration=PT1M
+security.github.cache.duration=3600
+security.github.cache.retryDuration=60

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -70,3 +70,9 @@ radar.admin.user=radar
 radar.admin.password=radar
 # Github Authentication
 security.github.client.token=
+security.github.client.timeout=PT10s
+# max content size 1 MB
+security.github.client.maxContentLength=1000000
+security.github.cache.size=10000
+security.github.cache.duration=PT1H
+security.github.cache.retryDuration=PT1M


### PR DESCRIPTION
- Use GithubClient inside GithubProtocolFetcherStrategy to improve readability and remove deplication.
- Use GithubService as a proxy for GithubClient in endpoint. This caches any values from the questionnaire.
- Created CachedFunction that caches the result of a throwing function for a given amount of time.
- Added more checks on the request being performed: number of bytes for content length, more strict URL validation (only `https://api.github.com/` is allowed now instead of for example `http://api.github.com.my.domain:9001/`.