### PR TITLE
Use async processing to avoid database timeouts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ ext {
     springBootVersion = '2.6.6'
     springVersion = '6.0.6'
     springOauth2Version = "2.5.1.RELEASE"
-    springDocVersion = '1.6.14'
+    springDocVersion = '2.2.0'
     lombokVersion = '1.18.26'
     junit5Version = '5.9.2'
     radarSpringAuthVersion = '1.2.0'
@@ -68,7 +68,7 @@ dependencies {
     runtimeOnly("org.hibernate.validator:hibernate-validator:$hibernateValidatorVersion")
 
     // Open API spec
-    implementation(group: 'org.springdoc', name: 'springdoc-openapi-ui', version: springDocVersion)
+    implementation(group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: springDocVersion)
 
 
     //runtimeOnly('org.springframework.boot:spring-boot-devtools')

--- a/src/main/java/org/radarbase/appserver/event/state/MessageStateEventListener.java
+++ b/src/main/java/org/radarbase/appserver/event/state/MessageStateEventListener.java
@@ -23,14 +23,18 @@ package org.radarbase.appserver.event.state;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.radarbase.appserver.event.state.dto.DataMessageStateEventDto;
 import org.radarbase.appserver.event.state.dto.NotificationStateEventDto;
 import org.radarbase.appserver.service.DataMessageStateEventService;
 import org.radarbase.appserver.service.NotificationStateEventService;
-import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.Map;
 
 @Slf4j
 @Component
@@ -55,7 +59,9 @@ public class MessageStateEventListener {
      *
      * @param event the event to respond to
      */
-    @EventListener(value = NotificationStateEventDto.class)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(classes = NotificationStateEventDto.class)
+    @Async
     public void onNotificationStateChange(NotificationStateEventDto event) {
         String info = convertMapToString(event.getAdditionalInfo());
         log.debug("ID: {}, STATE: {}", event.getNotification().getId(), event.getState());
@@ -65,7 +71,9 @@ public class MessageStateEventListener {
         notificationStateEventService.addNotificationStateEvent(eventEntity);
     }
 
-    @EventListener(value = DataMessageStateEventDto.class)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(value = DataMessageStateEventDto.class)
+    @Async
     public void onDataMessageStateChange(DataMessageStateEventDto event) {
         String info = convertMapToString(event.getAdditionalInfo());
         log.debug("ID: {}, STATE: {}", event.getDataMessage().getId(), event.getState());

--- a/src/main/java/org/radarbase/appserver/event/state/TaskStateEventListener.java
+++ b/src/main/java/org/radarbase/appserver/event/state/TaskStateEventListener.java
@@ -24,10 +24,15 @@ package org.radarbase.appserver.event.state;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.radarbase.appserver.event.state.dto.NotificationStateEventDto;
 import org.radarbase.appserver.event.state.dto.TaskStateEventDto;
 import org.radarbase.appserver.service.TaskStateEventService;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.util.Map;
 
@@ -51,7 +56,9 @@ public class TaskStateEventListener {
      *
      * @param event the event to respond to
      */
-    @EventListener(value = TaskStateEventDto.class)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(classes = TaskStateEventDto.class)
+    @Async
     public void onTaskStateChange(TaskStateEventDto event) {
         String info = convertMapToString(event.getAdditionalInfo());
         log.debug("ID: {}, STATE: {}", event.getTask().getId(), event.getState());

--- a/src/main/java/org/radarbase/appserver/service/GithubClient.java
+++ b/src/main/java/org/radarbase/appserver/service/GithubClient.java
@@ -97,7 +97,7 @@ public class GithubClient {
         try {
             return client.send(getRequest(uri), HttpResponse.BodyHandlers.ofInputStream());
         } catch (IOException ex) {
-            log.error("Failed to retrieve data from github: {}", ex.toString());
+            log.error("Failed to retrieve data from github {}: {}", uri, ex.toString());
             throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Github responded with an error.");
         }
     }

--- a/src/main/java/org/radarbase/appserver/service/TaskService.java
+++ b/src/main/java/org/radarbase/appserver/service/TaskService.java
@@ -159,14 +159,16 @@ public class TaskService {
     @Transactional
     public Task updateTaskStatus(Task oldTask, TaskState state) {
         User user = oldTask.getUser();
-        if (this.taskRepository.existsByUserIdAndNameAndTimestamp(user.getId(), oldTask.getName(), oldTask.getTimestamp())) {
-            if (state.equals(TaskState.COMPLETED)) {
-                oldTask.setCompleted(true);
-                oldTask.setTimeCompleted(Timestamp.from(Instant.now()));
-            }
-            oldTask.setStatus(state);
-            return this.taskRepository.saveAndFlush(oldTask);
-        } else throw new NotFoundException(
-                "The Task does not exists. Please Use add endpoint");
+
+        if (!this.taskRepository.existsByUserIdAndNameAndTimestamp(user.getId(), oldTask.getName(), oldTask.getTimestamp())) {
+            throw new NotFoundException("The Task " + oldTask.getId() + " does not exist to set to state " + state + ". Please Use add endpoint");
+        }
+
+        if (state.equals(TaskState.COMPLETED)) {
+            oldTask.setCompleted(true);
+            oldTask.setTimeCompleted(Timestamp.from(Instant.now()));
+        }
+        oldTask.setStatus(state);
+        return this.taskRepository.saveAndFlush(oldTask);
     }
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -100,7 +100,7 @@ security.radar.managementportal.url=http://localhost:8081
 #security.oauth2.client.userAuthorizationUri=
 # Github Authentication
 security.github.client.token=
-security.github.client.timeout=PT10s
+security.github.client.timeout=10
 # max content size 1 MB
 security.github.client.maxContentLength=1000000
 security.github.cache.size=10000


### PR DESCRIPTION
In the previous handling of events, event were handled immediately during the transaction, in the same thread. This caused a lot of delays, blocking the database threads. The `EventListener` annotations are replaced by `TransactionalEventListener` annotations to ensure that the previous transaction has been committed before processing the event. It explicitly creates a new transaction to avoid overlapping transactions. Finally, the `Async` annotation enables async processing to avoid the existing transaction threads being blocked.

This fixes an issue that caused timeouts if the fcm handling had timeouts.