### PR TITLE
Remove unused spring-data-rest dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,6 @@ sourceSets {
 
 dependencies {
     implementation('org.springframework.boot:spring-boot-starter-data-jpa')
-    implementation('org.springframework.boot:spring-boot-starter-data-rest')
     implementation('org.springframework.boot:spring-boot-starter-web')
     implementation('org.springframework.boot:spring-boot-starter-quartz')
     implementation('org.springframework.boot:spring-boot-starter-security')

--- a/src/main/java/org/radarbase/appserver/exception/NotificationAlreadyExistsException.java
+++ b/src/main/java/org/radarbase/appserver/exception/NotificationAlreadyExistsException.java
@@ -23,7 +23,7 @@ package org.radarbase.appserver.exception;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.NoArgsConstructor;
-import net.minidev.json.annotate.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.radarbase.appserver.dto.fcm.FcmNotificationDto;
 
 /**

--- a/src/main/java/org/radarbase/appserver/repository/DataMessageRepository.java
+++ b/src/main/java/org/radarbase/appserver/repository/DataMessageRepository.java
@@ -26,14 +26,12 @@ import java.util.List;
 import java.util.Optional;
 import org.radarbase.appserver.entity.DataMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
 
 /**
  * @author yatharthranjan
  */
 @Repository
-@RepositoryRestResource(exported = false)
 public interface DataMessageRepository extends JpaRepository<DataMessage, Long> {
 
     List<DataMessage> findByUserId(Long userId);

--- a/src/main/java/org/radarbase/appserver/repository/DataMessageStateEventRepository.java
+++ b/src/main/java/org/radarbase/appserver/repository/DataMessageStateEventRepository.java
@@ -24,11 +24,9 @@ package org.radarbase.appserver.repository;
 import java.util.List;
 import org.radarbase.appserver.entity.DataMessageStateEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@RepositoryRestResource(exported = false)
 public interface DataMessageStateEventRepository extends
         JpaRepository<DataMessageStateEvent, Long> {
 

--- a/src/main/java/org/radarbase/appserver/repository/NotificationRepository.java
+++ b/src/main/java/org/radarbase/appserver/repository/NotificationRepository.java
@@ -27,12 +27,10 @@ import java.util.Optional;
 import jakarta.validation.constraints.NotNull;
 import org.radarbase.appserver.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
 
 /** @author yatharthranjan */
 @Repository
-@RepositoryRestResource(exported = false)
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     List<Notification> findByUserId(Long userId);

--- a/src/main/java/org/radarbase/appserver/repository/NotificationStateEventRepository.java
+++ b/src/main/java/org/radarbase/appserver/repository/NotificationStateEventRepository.java
@@ -24,11 +24,9 @@ package org.radarbase.appserver.repository;
 import java.util.List;
 import org.radarbase.appserver.entity.NotificationStateEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@RepositoryRestResource(exported = false)
 public interface NotificationStateEventRepository extends
     JpaRepository<NotificationStateEvent, Long> {
 

--- a/src/main/java/org/radarbase/appserver/repository/ProjectRepository.java
+++ b/src/main/java/org/radarbase/appserver/repository/ProjectRepository.java
@@ -24,12 +24,10 @@ package org.radarbase.appserver.repository;
 import java.util.Optional;
 import org.radarbase.appserver.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
 
 /** @author yatharthranjan */
 @Repository
-@RepositoryRestResource(exported = false)
 public interface ProjectRepository extends JpaRepository<Project, Long> {
 
   Optional<Project> findByProjectId(String projectId);

--- a/src/main/java/org/radarbase/appserver/repository/TaskStateEventRepository.java
+++ b/src/main/java/org/radarbase/appserver/repository/TaskStateEventRepository.java
@@ -23,13 +23,11 @@ package org.radarbase.appserver.repository;
 
 import org.radarbase.appserver.entity.TaskStateEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-@RepositoryRestResource(exported = false)
 public interface TaskStateEventRepository extends
         JpaRepository<TaskStateEvent, Long> {
 

--- a/src/main/java/org/radarbase/appserver/repository/UserRepository.java
+++ b/src/main/java/org/radarbase/appserver/repository/UserRepository.java
@@ -26,12 +26,10 @@ import java.util.Optional;
 import jakarta.validation.constraints.NotNull;
 import org.radarbase.appserver.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
 
 /** @author yatharthranjan */
 @Repository
-@RepositoryRestResource(exported = false)
 public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findBySubjectId(String subjectId);


### PR DESCRIPTION
- Remove unused `spring-data-rest` dependency
- This exposed repository endpoints by default even when no controllers exist for them