### PR TITLE
Sending Response entities as exceptions.

### DIFF
--- a/src/main/java/org/radarbase/appserver/exception/entity/ErrorDetails.java
+++ b/src/main/java/org/radarbase/appserver/exception/entity/ErrorDetails.java
@@ -1,0 +1,17 @@
+package org.radarbase.appserver.exception.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ErrorDetails {
+    Instant timestamp;
+    int status;
+    String message;
+    String path;
+}

--- a/src/main/java/org/radarbase/appserver/exception/entity/ErrorDetailsWithCause.java
+++ b/src/main/java/org/radarbase/appserver/exception/entity/ErrorDetailsWithCause.java
@@ -1,0 +1,14 @@
+package org.radarbase.appserver.exception.entity;
+
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+public class ErrorDetailsWithCause extends ErrorDetails {
+    String cause;
+    public ErrorDetailsWithCause(Instant timestamp, int status, String cause, String message, String path) {
+        super(timestamp, status, message, path);
+        this.cause = cause;
+    }
+}

--- a/src/main/java/org/radarbase/appserver/exception/handler/ResponseEntityExceptionHandler.java
+++ b/src/main/java/org/radarbase/appserver/exception/handler/ResponseEntityExceptionHandler.java
@@ -17,48 +17,44 @@ public class ResponseEntityExceptionHandler {
 
     @ExceptionHandler(InvalidProjectDetailsException.class)
     public final ResponseEntity<ErrorDetails> handleInvalidProjectDetailsException(Exception ex, WebRequest request) throws Exception {
-        String cause = ex.getCause() != null ? ex.getCause().getMessage() : null;
-        HttpStatus status = ex.getClass().getAnnotation(ResponseStatus.class).value();
-        ErrorDetails error;
-        if (cause != null) {
-            error = new ErrorDetailsWithCause(Instant.now(), status.value(), cause, ex.getMessage(), request.getDescription(false));
-        } else {
-            error = new ErrorDetails(Instant.now(), status.value(), ex.getMessage(), request.getDescription(false));
-        }
-        return new ResponseEntity<>(error, status);
+        return handleEntityWithCause(ex, request);
     }
 
     @ExceptionHandler(AlreadyExistsException.class)
     public final ResponseEntity<ErrorDetails> handleAlreadyExistsException(Exception ex, WebRequest request) throws Exception {
-        HttpStatus status = ex.getClass().getAnnotation(ResponseStatus.class).value();
-        ErrorDetails error = new ErrorDetails(Instant.now(), status.value(), ex.getMessage(), request.getDescription(false));
-        return new ResponseEntity<>(error, status);
+        return handleEntityWithoutCause(ex, request);
     }
 
     @ExceptionHandler(NotFoundException.class)
     public final ResponseEntity<ErrorDetails> handleNotFoundException(Exception ex, WebRequest request) throws Exception {
-        HttpStatus status = ex.getClass().getAnnotation(ResponseStatus.class).value();
-        ErrorDetails error = new ErrorDetails(Instant.now(), status.value(), ex.getMessage(), request.getDescription(false));
-        return new ResponseEntity<>(error, status);
+        return handleEntityWithoutCause(ex, request);
     }
 
     @ExceptionHandler(InvalidNotificationDetailsException.class)
     public final ResponseEntity<ErrorDetails> handleInvalidNotificationDetailsException(Exception ex, WebRequest request) {
-        HttpStatus status = ex.getClass().getAnnotation(ResponseStatus.class).value();
-        ErrorDetails error = new ErrorDetails(Instant.now(), status.value(), ex.getMessage(), request.getDescription(false));
-        return new ResponseEntity<>(error, status);
+        return handleEntityWithoutCause(ex, request);
     }
 
     @ExceptionHandler(InvalidUserDetailsException.class)
     public final ResponseEntity<ErrorDetails> handleInvalidUserDetailsException(Exception ex, WebRequest request) {
-        HttpStatus status = ex.getClass().getAnnotation(ResponseStatus.class).value();
+        return handleEntityWithCause(ex, request);
+    }
+
+    public ResponseEntity<ErrorDetails> handleEntityWithCause(Exception ex, WebRequest request) {
         String cause = ex.getCause() != null ? ex.getCause().getMessage() : null;
+        HttpStatus status = ex.getClass().getAnnotation(ResponseStatus.class).value();
         ErrorDetails error;
         if (cause != null) {
             error = new ErrorDetailsWithCause(Instant.now(), status.value(), cause, ex.getMessage(), request.getDescription(false));
         } else {
             error = new ErrorDetails(Instant.now(), status.value(), ex.getMessage(), request.getDescription(false));
         }
+        return new ResponseEntity<>(error, status);
+    }
+
+    public ResponseEntity<ErrorDetails> handleEntityWithoutCause(Exception ex, WebRequest request) {
+        HttpStatus status = ex.getClass().getAnnotation(ResponseStatus.class).value();
+        ErrorDetails error = new ErrorDetails(Instant.now(), status.value(), ex.getMessage(), request.getDescription(false));
         return new ResponseEntity<>(error, status);
     }
 }

--- a/src/main/java/org/radarbase/appserver/exception/handler/ResponseEntityExceptionHandler.java
+++ b/src/main/java/org/radarbase/appserver/exception/handler/ResponseEntityExceptionHandler.java
@@ -1,0 +1,64 @@
+package org.radarbase.appserver.exception.handler;
+
+import org.radarbase.appserver.exception.*;
+import org.radarbase.appserver.exception.entity.ErrorDetails;
+import org.radarbase.appserver.exception.entity.ErrorDetailsWithCause;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.WebRequest;
+
+import java.time.Instant;
+
+@ControllerAdvice
+public class ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(InvalidProjectDetailsException.class)
+    public final ResponseEntity<ErrorDetails> handleInvalidProjectDetailsException(Exception ex, WebRequest request) throws Exception {
+        String cause = ex.getCause() != null ? ex.getCause().getMessage() : null;
+        HttpStatus status = ex.getClass().getAnnotation(ResponseStatus.class).value();
+        ErrorDetails error;
+        if (cause != null) {
+            error = new ErrorDetailsWithCause(Instant.now(), status.value(), cause, ex.getMessage(), request.getDescription(false));
+        } else {
+            error = new ErrorDetails(Instant.now(), status.value(), ex.getMessage(), request.getDescription(false));
+        }
+        return new ResponseEntity<>(error, status);
+    }
+
+    @ExceptionHandler(AlreadyExistsException.class)
+    public final ResponseEntity<ErrorDetails> handleAlreadyExistsException(Exception ex, WebRequest request) throws Exception {
+        HttpStatus status = ex.getClass().getAnnotation(ResponseStatus.class).value();
+        ErrorDetails error = new ErrorDetails(Instant.now(), status.value(), ex.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(error, status);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public final ResponseEntity<ErrorDetails> handleNotFoundException(Exception ex, WebRequest request) throws Exception {
+        HttpStatus status = ex.getClass().getAnnotation(ResponseStatus.class).value();
+        ErrorDetails error = new ErrorDetails(Instant.now(), status.value(), ex.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(error, status);
+    }
+
+    @ExceptionHandler(InvalidNotificationDetailsException.class)
+    public final ResponseEntity<ErrorDetails> handleInvalidNotificationDetailsException(Exception ex, WebRequest request) {
+        HttpStatus status = ex.getClass().getAnnotation(ResponseStatus.class).value();
+        ErrorDetails error = new ErrorDetails(Instant.now(), status.value(), ex.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(error, status);
+    }
+
+    @ExceptionHandler(InvalidUserDetailsException.class)
+    public final ResponseEntity<ErrorDetails> handleInvalidUserDetailsException(Exception ex, WebRequest request) {
+        HttpStatus status = ex.getClass().getAnnotation(ResponseStatus.class).value();
+        String cause = ex.getCause() != null ? ex.getCause().getMessage() : null;
+        ErrorDetails error;
+        if (cause != null) {
+            error = new ErrorDetailsWithCause(Instant.now(), status.value(), cause, ex.getMessage(), request.getDescription(false));
+        } else {
+            error = new ErrorDetails(Instant.now(), status.value(), ex.getMessage(), request.getDescription(false));
+        }
+        return new ResponseEntity<>(error, status);
+    }
+}

--- a/src/main/java/org/radarbase/appserver/exception/handler/ResponseEntityExceptionHandler.java
+++ b/src/main/java/org/radarbase/appserver/exception/handler/ResponseEntityExceptionHandler.java
@@ -15,6 +15,19 @@ import java.time.Instant;
 @ControllerAdvice
 public class ResponseEntityExceptionHandler {
 
+    @ExceptionHandler(Exception.class)
+    public final ResponseEntity<ErrorDetails> handleUnhandledException(Exception ex, WebRequest request) {
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        ErrorDetails error;
+        if (ex.getCause() == null) {
+           error = new ErrorDetails(Instant.now(), status.value(), ex.getMessage(), request.getDescription(false));
+        } else {
+            error = new ErrorDetailsWithCause(Instant.now(), status.value(), ex.getCause().getMessage(), ex.getMessage(), request.getDescription(false));
+        }
+        return new ResponseEntity<>(error, status);
+    }
+
+
     @ExceptionHandler(InvalidProjectDetailsException.class)
     public final ResponseEntity<ErrorDetails> handleInvalidProjectDetailsException(Exception ex, WebRequest request) throws Exception {
         return handleEntityWithCause(ex, request);


### PR DESCRIPTION
Updated Exception Handling mechanism, which involves sending ResponseEntities eg:

>{
    "timestamp": 1712402235.752647600,
    "status": 417,
    "message": "Invalid details supplied for the project ProjectDto(id=0, projectId=STAGING_PROJECT, createdAt=2023-04-06T13:31:32.897Z, updatedAt=2024-04-06T13:31:32.897Z)",
    "path": "uri=/projects",
    "cause": "'id' must not be supplied when creating a project as it is autogenerated."
}

Right now which is:
>{
  "timestamp": 1712563716402,
  "status": 417,
  "error": "Expectation Failed",
  "path": "/projects"
}

@yatharthranjan, @mpgxvii
Please review this and let me know if you have any suggestions for improvement.
Thanks