### PR TITLE
Add default notification protocol value

### DIFF
--- a/src/main/java/org/radarbase/appserver/dto/protocol/AssessmentProtocol.java
+++ b/src/main/java/org/radarbase/appserver/dto/protocol/AssessmentProtocol.java
@@ -46,7 +46,7 @@ public class AssessmentProtocol {
 
     private ClinicalProtocol clinicalProtocol;
 
-    private NotificationProtocol notification;
+    private NotificationProtocol notification = new NotificationProtocol();
 
     @JsonDeserialize(using = ReferenceTimestampDeserializer.class)
     public void setReferenceTimestamp(Object responseObject) {


### PR DESCRIPTION
- Adds a default notification protocol value since this is optional in the protocol schema
- When this is empty, a `NullPointerException` is thrown

```
java.lang.NullPointerException: Cannot invoke "org.radarbase.appserver.dto.protocol.NotificationProtocol.getMode()" because "protocol" is null
```