### PR TITLE
Impl. send-email endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,32 @@
 
 General purpose application server for the radar platform currently with capability to schedule push notifications.
 
+<!-- TOC -->
+* [RADAR-Appserver](#radar-appserver)
+  * [Introduction](#introduction)
+  * [Getting Started](#getting-started)
+  * [REST API](#rest-api)
+    * [Quickstart](#quickstart)
+  * [FCM](#fcm)
+    * [AdminSDK](#adminsdk)
+  * [Docker/ Docker Compose](#docker-docker-compose)
+  * [Architecture](#architecture)
+  * [Notification Lifecycle](#notification-lifecycle)
+  * [Protocols](#protocols)
+  * [Documentation](#documentation)
+  * [Client](#client)
+  * [Security](#security)
+    * [Management Portal](#management-portal)
+    * [Management Portal Clients](#management-portal-clients)
+    * [Other Security Providers](#other-security-providers)
+  * [Monitoring](#monitoring)
+  * [Performance Testing](#performance-testing)
+  * [Code-Style and Quality](#code-style-and-quality)
+  * [Unit and Integration Testing](#unit-and-integration-testing)
+  * [Features](#features)
+    * [Feature specific documentation](#feature-specific-documentation)
+<!-- TOC -->
+
 ## Introduction
 
 This is an app server which provides facilities to store app information (User related) and scheduling of push notifications using Firebase Cloud Messaging. 
@@ -489,7 +515,7 @@ A style template following the Google Java style guidelines is also provided for
 ```
 This will run checkstyle, PMD, spot bugs, unit tests and integration tests.
 
-## Current Features
+## Features
 - Provides a general purpose FCM library with facility to send messages with Admin SDK support.
 - Provides functionality of scheduling notifications via FCM.
 - Acts as a data store for important user and app related data (like FCM token to subject mapping, notifications, user metrics, etc).
@@ -498,3 +524,7 @@ This will run checkstyle, PMD, spot bugs, unit tests and integration tests.
 - Contains swagger integration for easy API documentation and generation of Java client.
 - Uses [lombok.data](https://projectlombok.org/) in most places to reduce boilerplate code and make it more readable.
 - Has support for Auditing of database entities.
+- Send emails from study subjects (originating from aRMT application) via Firebase _Trigger Email from Firestore_ extension.
+
+### Feature specific documentation
+- [Send emails](/docs/send-emails.md)

--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,7 @@ dependencies {
     testImplementation group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.8.2'
     testImplementation group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.8.2'
     testImplementation group: 'org.junit.platform', name: 'junit-platform-engine', version: '1.8.2'
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '2.7.21'
 
     gatlingImplementation('com.fasterxml.jackson.datatype:jackson-datatype-jsr310')
 }

--- a/docs/send-emails.md
+++ b/docs/send-emails.md
@@ -1,0 +1,32 @@
+# Send emails feature
+
+Appserver can send emails from the aRMT app on behalf of the study subject. Sending of emails is triggered by making a
+POST message to the `/email/projects/{{projectId}}/users/{{subjectId}}` endpoint with a body that has the following
+structure:
+
+```json
+{
+  "to": "me@there.org",
+  "cc": "you@there.org;andyou@there.org",
+  "bcc": "everyone@there.org",
+  "subject": "Hi!",
+  "message": "How <b>you</b> doin ... !?"
+}
+```
+
+The way how emails are sent is polymorphic. At present, the only method is by using the Firebase Trigger Email from
+Firestore extension. This method involves placing a JSON document in the Firebase database collection. The extension is
+configured to send emails from this database collection.
+
+## Configuration of the Firebase Trigger Email from Firestore extension
+
+To activate the email endpoint and configure Firebase emails set the following application properties in the
+`application.properties` file:
+
+```
+send-email.enabled=true
+send-email.type=firebase
+```
+
+To setup the _Using the Trigger Email extension_, log into your Firebase project console and follow the installation
+instructions as described in the [extension docs](https://firebase.google.com/docs/extensions/official/firestore-send-email).

--- a/src/main/java/org/radarbase/appserver/controller/EmailController.java
+++ b/src/main/java/org/radarbase/appserver/controller/EmailController.java
@@ -1,0 +1,70 @@
+/*
+ *
+ *  *  Copyright 2024 The Hyve
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *
+ */
+
+package org.radarbase.appserver.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.radarbase.appserver.config.AuthConfig.AuthEntities;
+import org.radarbase.appserver.config.AuthConfig.AuthPermissions;
+import org.radarbase.appserver.controller.model.SendEmailRequest;
+import org.radarbase.appserver.service.EmailService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import radar.spring.auth.common.Authorized;
+import radar.spring.auth.common.PermissionOn;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Endpoint for sending emails from app on behalf of the study subject.
+ *
+ * @author Pim van Nierop
+ */
+@CrossOrigin
+@RestController
+@ConditionalOnProperty(value = "send-email.enabled", havingValue = "true")
+@Slf4j
+public class EmailController {
+
+  @Autowired
+  private EmailService emailService;
+
+  @Authorized(
+      permission = AuthPermissions.UPDATE,
+      entity = AuthEntities.SUBJECT,
+      permissionOn = PermissionOn.SUBJECT
+  )
+  @PostMapping(
+      "/email/" + PathsUtil.PROJECT_PATH + "/" + PathsUtil.PROJECT_ID_CONSTANT +
+      "/" + PathsUtil.USER_PATH + "/" + PathsUtil.SUBJECT_ID_CONSTANT)
+  public CompletableFuture<Boolean> subjectSendEmail(
+      @PathVariable String projectId,
+      @PathVariable String subjectId,
+      @RequestBody SendEmailRequest sendEmailRequest) {
+
+    log.info("Sending email for project: {}, subject: {}", projectId, subjectId);
+
+    return emailService.send(sendEmailRequest);
+  }
+
+}

--- a/src/main/java/org/radarbase/appserver/controller/model/SendEmailRequest.java
+++ b/src/main/java/org/radarbase/appserver/controller/model/SendEmailRequest.java
@@ -1,0 +1,4 @@
+package org.radarbase.appserver.controller.model;
+
+public record SendEmailRequest(String subject, String message, String to, String cc, String bcc) {
+}

--- a/src/main/java/org/radarbase/appserver/service/EmailService.java
+++ b/src/main/java/org/radarbase/appserver/service/EmailService.java
@@ -1,0 +1,9 @@
+package org.radarbase.appserver.service;
+
+import org.radarbase.appserver.controller.model.SendEmailRequest;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface EmailService {
+    CompletableFuture<Boolean> send(SendEmailRequest sendEmailRequest);
+}

--- a/src/main/java/org/radarbase/appserver/service/FirebaseEmailService.java
+++ b/src/main/java/org/radarbase/appserver/service/FirebaseEmailService.java
@@ -1,0 +1,81 @@
+/*
+ *
+ *  *  Copyright 2024 The Hyve
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *
+ */
+
+package org.radarbase.appserver.service;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.radarbase.appserver.controller.model.SendEmailRequest;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+
+@Slf4j
+@Service
+@ConditionalOnExpression("${send-email.enabled:false} and 'firebase' == '${email.type:}'")
+public class FirebaseEmailService implements EmailService {
+
+    @Override
+    @Async
+    public CompletableFuture<Boolean> send(SendEmailRequest emailRequest) {
+
+        Assert.notNull(emailRequest, "Send email request cannot be null");
+        Assert.isTrue(!emailRequest.to().isEmpty(), "Send email request must have a recipient");
+        Assert.isTrue(!emailRequest.subject().isEmpty(), "Send email request must have a subject");
+        Assert.isTrue(!emailRequest.message().isEmpty(), "Send email request must have a message");
+        try {
+            // Sending emails using Firebase works by placing a document in the Firebase Firestore.
+            // Firebase will then trigger a cloud function that sends the email.
+            Firestore firestore = FirestoreOptions.getDefaultInstance().getService();
+            CollectionReference mailCollection = firestore.collection("mail");
+            ApiFuture<DocumentReference> apiFuture = mailCollection.add(createEmailMap(emailRequest));
+            apiFuture.get();
+        } catch (InterruptedException | ExecutionException e) {
+            Thread.currentThread().interrupt();
+            log.error("Error sending email", e);
+            return CompletableFuture.completedFuture(false);
+        }
+        log.debug("Email sent successfully");
+        return CompletableFuture.completedFuture(true);
+    }
+
+    // The 'from' email address is configured in Firebase.
+    private Map<String, Object> createEmailMap(SendEmailRequest emailRequest) {
+        Map<String, String> messageMap = new HashMap<>();
+        messageMap.put("subject", emailRequest.subject());
+        messageMap.put("html", emailRequest.message());
+        Map<String, Object> emailMap = new HashMap<>();
+        emailMap.put("to", emailRequest.to());
+        emailMap.put("cc", emailRequest.cc());
+        emailMap.put("bcc", emailRequest.bcc());
+        emailMap.put("message", messageMap);
+        return emailMap;
+    }
+
+}

--- a/src/main/java/org/radarbase/appserver/service/FirebaseEmailService.java
+++ b/src/main/java/org/radarbase/appserver/service/FirebaseEmailService.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ExecutionException;
 
 @Slf4j
 @Service
-@ConditionalOnExpression("${send-email.enabled:false} and 'firebase' == '${email.type:}'")
+@ConditionalOnExpression("${send-email.enabled:false} and 'firebase' == '${send-email.type:}'")
 public class FirebaseEmailService implements EmailService {
 
     @Override

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -80,4 +80,4 @@ security.github.cache.retryDuration=60
 # SEND EMAIL
 send-email.enabled=true
 # can be 'firebase' (smtp is not supported yet)
-email.type=firebase
+send-email.type=firebase

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -76,3 +76,8 @@ security.github.client.maxContentLength=1000000
 security.github.cache.size=10000
 security.github.cache.duration=3600
 security.github.cache.retryDuration=60
+
+# SEND EMAIL
+send-email.enabled=true
+# can be 'firebase' (smtp is not supported yet)
+email.type=firebase

--- a/src/test/java/org/radarbase/appserver/service/storage/FirebaseEmailServiceTest.java
+++ b/src/test/java/org/radarbase/appserver/service/storage/FirebaseEmailServiceTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.when;
     classes = {FirebaseEmailService.class},
     properties = {
         "send-email.enabled=true",
-        "email.type=firebase",
+        "send-email.type=firebase",
     }
 )
 class FirebaseEmailServiceTest {

--- a/src/test/java/org/radarbase/appserver/service/storage/FirebaseEmailServiceTest.java
+++ b/src/test/java/org/radarbase/appserver/service/storage/FirebaseEmailServiceTest.java
@@ -1,0 +1,114 @@
+/*
+ *
+ *  *  Copyright 2024 The Hyve
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *
+ */
+
+package org.radarbase.appserver.service.storage;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.radarbase.appserver.controller.model.SendEmailRequest;
+import org.radarbase.appserver.service.FirebaseEmailService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(
+    classes = {FirebaseEmailService.class},
+    properties = {
+        "send-email.enabled=true",
+        "email.type=firebase",
+    }
+)
+class FirebaseEmailServiceTest {
+
+    @Autowired
+    private FirebaseEmailService firebaseEmailService;
+
+    private SendEmailRequest validEmailRequest = new SendEmailRequest(
+        "subject", "message", "to", "cc", "bcc"
+    );
+    private CollectionReference mailCollection;
+    private MockedStatic<FirestoreOptions> firestoreOptionsStatic;
+    private ApiFuture firebaseApiFuture;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        firestoreOptionsStatic = Mockito.mockStatic(FirestoreOptions.class);
+        Firestore firestore = Mockito.mock(Firestore.class);
+        FirestoreOptions firestoreOptionsInstance = Mockito.mock(FirestoreOptions.class);
+        when(firestoreOptionsInstance.getService()).thenReturn(firestore);
+        firestoreOptionsStatic.when(FirestoreOptions::getDefaultInstance).thenReturn(firestoreOptionsInstance);
+
+        mailCollection = mock(CollectionReference.class);
+        when(firestore.collection("mail")).thenReturn(mailCollection);
+
+        firebaseApiFuture = mock(ApiFuture.class);
+        when(mailCollection.add(anyMap())).thenReturn(firebaseApiFuture);
+        when(firebaseApiFuture.get()).thenReturn(null);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        firestoreOptionsStatic.close();
+    }
+
+    @Test
+    void testArguments() {
+        assertDoesNotThrow(() -> firebaseEmailService.send(validEmailRequest));
+        assertDoesNotThrow(() -> firebaseEmailService.send(new SendEmailRequest("subject", "message", "to", null, null)));
+        assertThrows(Exception.class, () -> firebaseEmailService.send(new SendEmailRequest(null, "message", "to", "cc", "bcc")));
+        assertThrows(Exception.class, () -> firebaseEmailService.send(new SendEmailRequest("subject", null, "to", "cc", "bcc")));
+        assertThrows(Exception.class, () -> firebaseEmailService.send(new SendEmailRequest("subject", "message", null, "cc", "bcc")));
+    }
+
+    @Test
+    void testSendEmail() throws Exception {
+        CompletableFuture<Boolean> future = firebaseEmailService.send(validEmailRequest);
+        Boolean success = future.get();
+        assertTrue(success);
+        verify(mailCollection, times(1)).add(anyMap());
+    }
+
+    @Test
+    void testFailSendEmail() throws Exception {
+        when(firebaseApiFuture.get()).thenThrow(new InterruptedException());
+        CompletableFuture<Boolean> future = firebaseEmailService.send(validEmailRequest);
+        Boolean success = future.get();
+        assertTrue(!success);
+    }
+
+}


### PR DESCRIPTION
We currently are building functionality to allow sending emails from aRMT app on behalf of the study subject. The use case is that study subject are allowed to contact their assigned physician from within the app so that any problems or questions can be raised in a convenient manner.

This PR will implement a new POST endpoint `/email/projects/<projectId>/users/<subjectId>` endpoint. This endpoint receives a post body with structure:

```
{
  "to": "me@there.org",
  "cc": "you@there.org;andyou@there.org",
  "bcc": "everyone@there.org",
  "subject": "Hi!",
  "message": "How <i>you</i> doin...."
}
```

In response the Appserver will send the email.

The way how emails are sent is polymorphic. At present, the only method is by using the Firebase [Trigger Email from Firestore](https://extensions.dev/extensions/firebase/firestore-send-email) extension. This method involves placing a JSON document in the Firebase database collection. The extension is configured to send emails from this database collection.

In the future, we can implement a way to directly send emails from Appserver. This would require to register SMTP server credentials in the service.

# Remarks
- At the moment I did not implement some for of rate limiting for sending email. Lets discuss whether we think this is needed.
- In the current implementation, the aRMT app is responsible for defining all aspects of the email including the `to`, `cc` and `bcc` fields. In theory this would allow a subject to spam the whole world with emails. Lets discuss whether we need to change this.

