### PR TITLE
Fixed addition of attributes when creating new user

### DIFF
--- a/src/main/java/org/radarbase/appserver/converter/UserConverter.java
+++ b/src/main/java/org/radarbase/appserver/converter/UserConverter.java
@@ -58,7 +58,8 @@ public class UserConverter implements Converter<User, FcmUserDto> {
         .setUserMetrics(getValidUserMetrics(fcmUserDto))
         .setEnrolmentDate(fcmUserDto.getEnrolmentDate())
         .setTimezone(fcmUserDto.getTimezone())
-        .setLanguage(fcmUserDto.getLanguage());
+        .setLanguage(fcmUserDto.getLanguage())
+        .setAttributes(fcmUserDto.getAttributes());
   }
 
   @Override


### PR DESCRIPTION
When making a POST request to the user endpoint, the user's attributes are not saved, failing the following [code from GithubProtocolFetcherStrategy ](https://github.com/RADAR-base/RADAR-Appserver/blob/c8c04392b1a38135e8d47e13734e7841237278ef/src/main/java/org/radarbase/appserver/service/questionnaire/protocol/GithubProtocolFetcherStrategy.java#L135)to retrieve user attributes:

`Map<String, String> attributes = u.getAttributes() != null ? u.getAttributes() : Map.of();`  

This approach is effective only when updating an existing user.

Additionally, when setting attributes as shown below:

`"attributes": {
  "arm": "test_audio",
  "arm": "test_kcl",
  "arm": "test_health"
}
`

Only the last key-value pair is obtained due to the internal implementation using HashMap, which allows unique keys.

If this behavior is intentional and no updates are necessary, please feel free to close this PR.
