### PR TITLE
Add default empty email notification protocol

### DIFF
--- a/src/main/java/org/radarbase/appserver/dto/protocol/NotificationProtocol.java
+++ b/src/main/java/org/radarbase/appserver/dto/protocol/NotificationProtocol.java
@@ -45,6 +45,6 @@ public class NotificationProtocol {
     private LanguageText body;
 
     @JsonProperty("email")
-    private EmailNotificationProtocol email;
+    private EmailNotificationProtocol email = new EmailNotificationProtocol();
 }
 


### PR DESCRIPTION
- Add default empty email notification protocol when this is not specified in the protocol