### PR TITLE
Disable Spring Boot mail autoconfiguration when not sending notifications via email

### DIFF
--- a/src/main/java/org/radarbase/appserver/config/MailAutoconfigureExcludeConfig.java
+++ b/src/main/java/org/radarbase/appserver/config/MailAutoconfigureExcludeConfig.java
@@ -1,0 +1,13 @@
+package org.radarbase.appserver.config;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(value = "radar.notification.email.enabled", havingValue = "false", matchIfMissing = true)
+@EnableAutoConfiguration(exclude = {
+    org.springframework.boot.autoconfigure.mail.MailSenderAutoConfiguration.class,
+    org.springframework.boot.autoconfigure.mail.MailSenderValidatorAutoConfiguration.class
+})
+public class MailAutoconfigureExcludeConfig { }


### PR DESCRIPTION
# Problem
When notifications via email is disabled in the config, the spring boot autoconfig would still validate the mail server credentials. This causes non-applicable mail server related errors when the email server was not correctly configured.  

# Solution
This PR will disable the Spring Boot mail autoconfiguration when sending email notifications is disabled.