### PR TITLE
Add support for Sentry monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,24 @@ Deploying the Spring Boot Admin server and the client as different components ma
 used to register multiple client apps and the server's lifecycle is not associated with the client. This also means that
 our client app is lighter and production ready.
 
+### Sentry monitoring
+
+To enable Sentry monitoring:
+
+1. Add the `sentry` profile to active spring profiles.
+2. Set a `SENTRY_DSN` environment variable that points to the desired Sentry DSN.
+3. (Optional) Set the `SENTRY_LOG_LEVEL` environment variable to control the minimum log level of events sent to Sentry.
+   The default log level for Sentry is `ERROR`. Possible values are `TRACE`, `DEBUG`, `INFO`, `WARN`, and `ERROR`.
+
+For further configuration of Sentry via environmental variables see [here](https://docs.sentry.io/platforms/java/configuration/#configuration-via-the-runtime-environment). For instance:
+
+```
+SENTRY_LOG_LEVEL: 'ERROR'
+SENTRY_DSN: 'https://000000000000.ingest.de.sentry.io/000000000000'
+SENTRY_ATTACHSTACKTRACE: true
+SENTRY_STACKTRACE_APP_PACKAGES: org.radarbase.appserver
+```
+
 ## Performance Testing
 
 The app server supports performance testing using Gatling and Scala. The simulations are located in the

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'pmd'
     id 'io.gatling.gradle' version '3.9.2.1'
     id 'com.github.johnrengelman.shadow' version '8.1.0'
-    id 'org.springframework.boot' version '3.2.10'
+    id 'org.springframework.boot' version '3.2.11'
     id 'org.openjfx.javafxplugin' version '0.0.13'
     id("com.github.ben-manes.versions") version "0.46.0"
     id 'io.sentry.jvm.gradle' version '4.11.0'
@@ -33,7 +33,7 @@ bootJar {
 }
 
 ext {
-    springBootVersion = '3.2.10'
+    springBootVersion = '3.2.11'
     springVersion = '6.0.6'
     springOauth2Version = "2.5.2.RELEASE"
     springOauth2AutoconfigureVersion = "2.6.8"

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'org.springframework.boot' version '3.2.10'
     id 'org.openjfx.javafxplugin' version '0.0.13'
     id("com.github.ben-manes.versions") version "0.46.0"
+    id 'io.sentry.jvm.gradle' version '4.11.0'
 }
 
 apply plugin: 'checkstyle'

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -59,12 +59,18 @@
     </filter>
   </appender>
 
+  <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+    <minimumEventLevel>${SENTRY_LOG_LEVEL:-ERROR}</minimumEventLevel>
+  </appender>
 
   <!-- LOG everything at INFO level -->
   <root level="info">
     <appender-ref ref="RollingFile" />
     <appender-ref ref="Console" />
     <appender-ref ref="RollingFile-Error" />
+    <springProfile name="sentry">
+      <appender-ref ref="Sentry"/>
+    </springProfile>
   </root>
 
 </configuration>


### PR DESCRIPTION
Description: This PR will add option to monitor the application with Sentry. Sentry monitoring will be enabled by the following:

1. Add the `sentry` profile to active spring profiles.
2. Set a `SENTRY_DSN` environment variable that points to the desired Sentry DSN.
3. (Optional) Set the `SENTRY_LOG_LEVEL` environment variable to control the minimum log level of events sent to Sentry.
   The default log level for Sentry is `ERROR`. Possible values are `TRACE`, `DEBUG`, `INFO`, `WARN`, and `ERROR`.

The docs were updated with these instructions.