### PR TITLE
Remove schedule generation on user creation

### DIFF
--- a/src/main/java/org/radarbase/appserver/service/UserService.java
+++ b/src/main/java/org/radarbase/appserver/service/UserService.java
@@ -57,8 +57,6 @@ public class UserService {
   private final transient UserRepository userRepository;
   private final transient ProjectRepository projectRepository;
 
-  @Autowired
-  private final transient QuestionnaireScheduleService scheduleService;
 
   private static final String FCM_TOKEN_PREFIX = "unregistered_";
 
@@ -66,12 +64,10 @@ public class UserService {
   public UserService(
       UserConverter userConverter,
       UserRepository userRepository,
-      ProjectRepository projectRepository,
-      QuestionnaireScheduleService scheduleService) {
+      ProjectRepository projectRepository) {
     this.userConverter = userConverter;
     this.userRepository = userRepository;
     this.projectRepository = projectRepository;
-    this.scheduleService = scheduleService;
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/org/radarbase/appserver/service/UserService.java
+++ b/src/main/java/org/radarbase/appserver/service/UserService.java
@@ -165,8 +165,6 @@ public class UserService {
     // maintain a bi-directional relationship
     newUser.getUsermetrics().setUser(newUser);
     User savedUser = this.userRepository.saveAndFlush(newUser);
-    // Generate schedule for user
-    this.scheduleService.generateScheduleForUser(savedUser);
     return userConverter.entityToDto(savedUser);
   }
 
@@ -195,14 +193,6 @@ public class UserService {
     // maintain a bi-directional relationship
     user.getUsermetrics().setUser(user);
     User savedUser = this.userRepository.saveAndFlush(user);
-    // Generate schedule for user
-    if (!user.getAttributes().equals(userDto.getAttributes())
-            || !user.getTimezone().equals(userDto.getTimezone())
-            || !user.getEnrolmentDate().equals(userDto.getEnrolmentDate())
-            || !user.getLanguage().equals(userDto.getLanguage()))
-    {
-      this.scheduleService.generateScheduleForUser(savedUser);
-    }
     return userConverter.entityToDto(savedUser);
   }
 

--- a/src/test/java/org/radarbase/appserver/service/UserServiceTest.java
+++ b/src/test/java/org/radarbase/appserver/service/UserServiceTest.java
@@ -65,9 +65,6 @@ class UserServiceTest {
     @MockBean
     private transient ProjectRepository projectRepository;
 
-    @MockBean
-    private transient QuestionnaireScheduleService scheduleService;
-
     private transient Instant enrolmentDate = Instant.now().plus(Duration.ofSeconds(100));
     private static final String TIMEZONE = "Europe/Bucharest";
 
@@ -217,14 +214,11 @@ class UserServiceTest {
         @Autowired
         private transient ProjectRepository projectRepository;
 
-        @Autowired
-        private transient QuestionnaireScheduleService scheduleService;
-
         private final transient UserConverter userConverter = new UserConverter();
 
         @Bean
         public UserService userServiceBeanConfig() {
-            return new UserService(userConverter, userRepository, projectRepository, scheduleService);
+            return new UserService(userConverter, userRepository, projectRepository);
         }
     }
 }


### PR DESCRIPTION
- Currently, when a user gets created or updated, the task schedule for them gets automatically generated
- This update will remove this and the separate `/schedule` endpoint can simply get called
- This has also been causing delays in active app enrolment