### PR TITLE
fix/filter-duplicate-notifications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: 'scala'
 
 group = 'org.radarbase'
-version = '2.4.5'
+version = '2.4.6'
 
 java {
     toolchain {

--- a/src/main/java/org/radarbase/appserver/controller/QuestionnaireScheduleEndpoint.java
+++ b/src/main/java/org/radarbase/appserver/controller/QuestionnaireScheduleEndpoint.java
@@ -23,7 +23,6 @@ package org.radarbase.appserver.controller;
 
 import org.radarbase.appserver.dto.protocol.Assessment;
 import org.radarbase.appserver.dto.protocol.AssessmentType;
-import org.radarbase.appserver.dto.questionnaire.Schedule;
 import org.radarbase.appserver.entity.Task;
 import org.radarbase.appserver.service.QuestionnaireScheduleService;
 import org.radarbase.appserver.config.AuthConfig.AuthEntities;
@@ -91,8 +90,7 @@ public class QuestionnaireScheduleEndpoint {
     public ResponseEntity generateScheduleUsingProtocol(
             @PathVariable String projectId,
             @PathVariable String subjectId,
-            @Valid @RequestBody Assessment assessment)
-            throws URISyntaxException {
+            @Valid @RequestBody Assessment assessment) {
         try {
             this.scheduleService.generateScheduleUsingProjectIdAndSubjectIdAndAssessment(projectId, subjectId, assessment);
             return ResponseEntity.created(

--- a/src/main/java/org/radarbase/appserver/entity/Task.java
+++ b/src/main/java/org/radarbase/appserver/entity/Task.java
@@ -23,8 +23,6 @@ package org.radarbase.appserver.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.ser.InstantSerializer;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -39,7 +37,7 @@ import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.temporal.ChronoField;
+import java.util.Objects;
 
 @Entity
 @Table(
@@ -245,4 +243,21 @@ public class Task extends AuditModel implements Serializable {
         }
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Task task)) {
+            return false;
+        }
+        return Objects.equals(getUser(), task.getUser())
+                && Objects.equals(getTimestamp(), task.getTimestamp())
+                && Objects.equals(getName(), task.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getUser(), getTimestamp(), getName());
+    }
 }

--- a/src/main/java/org/radarbase/appserver/service/QuestionnaireScheduleService.java
+++ b/src/main/java/org/radarbase/appserver/service/QuestionnaireScheduleService.java
@@ -40,7 +40,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -186,13 +185,6 @@ public class QuestionnaireScheduleService {
 
         this.saveTasksAndNotifications(List.of(a), user);
         return schedule;
-    }
-
-    @Scheduled(fixedRate = 3_600_000)
-    public void generateAllSchedules() {
-        List<User> users = this.userRepository.findAll();
-        log.info("Generating all schedules..");
-        users.forEach(this::generateScheduleForUser);
     }
 
     public Schedule getScheduleForSubject(String subjectId) {

--- a/src/main/java/org/radarbase/appserver/service/questionnaire/protocol/RandomRepeatQuestionnaireHandler.java
+++ b/src/main/java/org/radarbase/appserver/service/questionnaire/protocol/RandomRepeatQuestionnaireHandler.java
@@ -27,12 +27,12 @@ import org.radarbase.appserver.dto.protocol.TimePeriod;
 import org.radarbase.appserver.dto.questionnaire.AssessmentSchedule;
 import org.radarbase.appserver.entity.Task;
 import org.radarbase.appserver.entity.User;
-import org.radarbase.appserver.service.TaskService;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.TimeZone;
 
 @SuppressWarnings("PMD.DataflowAnomalyAnalysis")
@@ -45,18 +45,21 @@ public class RandomRepeatQuestionnaireHandler implements ProtocolHandler {
     public RandomRepeatQuestionnaireHandler() { }
 
     public AssessmentSchedule handle(AssessmentSchedule assessmentSchedule, Assessment assessment, User user) {
-        List<Task> tasks = generateTasks(assessment, assessmentSchedule.getReferenceTimestamps(), user);
-        assessmentSchedule.setTasks(tasks);
+        Set<Task> tasks = generateTasks(assessment, assessmentSchedule.getReferenceTimestamps(), user);
+        assessmentSchedule.setTasks(List.copyOf(tasks));
         return assessmentSchedule;
     }
 
-    private List<Task> generateTasks(Assessment assessment, List<Instant> referenceTimestamps, User user) {
+    private Set<Task> generateTasks(Assessment assessment, List<Instant> referenceTimestamps, User user) {
         TimeZone timezone = TimeZone.getTimeZone(user.getTimezone());
         RepeatQuestionnaire repeatQuestionnaire = assessment.getProtocol().getRepeatQuestionnaire();
         List<Integer[]> randomUnitsFromZeroBetween = repeatQuestionnaire.getRandomUnitsFromZeroBetween();
         Iterator<Instant> referenceTimestampsIter = referenceTimestamps.iterator();
         Long completionWindow = this.calculateCompletionWindow(assessment.getProtocol().getCompletionWindow());
-        List<Task> tasks = new ArrayList<>();
+        // Specific (edge case) combinations of repeatProtocol and repeatQuestionnaire may lead to Tasks with identical
+        // name, user id and scheduling time, causing downstream key constraint errors when storing Notifications.
+        // Deduplication of Task objects generated here solves this.
+        Set<Task> tasks = new LinkedHashSet<>();
         while (referenceTimestampsIter.hasNext()) {
             Instant referenceTimestamp = referenceTimestampsIter.next();
             TimePeriod timePeriod = new TimePeriod();
@@ -71,6 +74,7 @@ public class RandomRepeatQuestionnaireHandler implements ProtocolHandler {
                 tasks.add(task);
             }
         }
+
         return tasks;
     }
 

--- a/src/main/java/org/radarbase/appserver/service/questionnaire/protocol/SimpleRepeatQuestionnaireHandler.java
+++ b/src/main/java/org/radarbase/appserver/service/questionnaire/protocol/SimpleRepeatQuestionnaireHandler.java
@@ -42,33 +42,32 @@ public class SimpleRepeatQuestionnaireHandler implements ProtocolHandler {
     public SimpleRepeatQuestionnaireHandler() { }
 
     public AssessmentSchedule handle(AssessmentSchedule assessmentSchedule, Assessment assessment, User user) {
-        List<Task> tasks = generateTasks(assessment, assessmentSchedule.getReferenceTimestamps(), user);
-        assessmentSchedule.setTasks(tasks);
+        Set<Task> tasks = generateTasks(assessment, assessmentSchedule.getReferenceTimestamps(), user);
+        assessmentSchedule.setTasks(List.copyOf(tasks));
         return assessmentSchedule;
     }
 
-    private List<Task> generateTasks(Assessment assessment, List<Instant> referenceTimestamps, User user) {
+    private Set<Task> generateTasks(Assessment assessment, List<Instant> referenceTimestamps, User user) {
         TimeZone timezone = TimeZone.getTimeZone(user.getTimezone());
         RepeatQuestionnaire repeatQuestionnaire = assessment.getProtocol().getRepeatQuestionnaire();
         List<Integer> unitsFromZero = repeatQuestionnaire.getUnitsFromZero();
         Long completionWindow = this.calculateCompletionWindow(assessment.getProtocol().getCompletionWindow());
-
-        List<Task> tasks = referenceTimestamps.parallelStream()
+        // Specific (edge case) combinations of repeatProtocol and repeatQuestionnaire may lead to Tasks with identical
+        // name, user id and scheduling time, causing downstream key constraint errors when storing Notifications.
+        // Deduplication of Task objects generated here solves this.
+        return referenceTimestamps.parallelStream()
                 .flatMap(referenceTimestamp -> {
                     TimePeriod timePeriod = new TimePeriod();
                     timePeriod.setUnit(repeatQuestionnaire.getUnit());
-                    List<Task> t = unitsFromZero.parallelStream()
+                    return unitsFromZero.parallelStream()
                             .map(unitFromZero -> {
                                 timePeriod.setAmount(unitFromZero);
                                 Instant taskTime = timeCalculatorService.advanceRepeat(referenceTimestamp, timePeriod, timezone);
                                 Task task = taskGeneratorService.buildTask(assessment, taskTime, completionWindow);
                                 task.setUser(user);
                                 return task;
-                            }).collect(Collectors.toList());
-                    return t.stream();
-                }).collect(Collectors.toList());
-
-        return tasks;
+                            });
+                }).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private Long calculateCompletionWindow(TimePeriod completionWindow) {


### PR DESCRIPTION

### Problem
Registration of a new user in a study that is using the STAGING_PROJECT super-protocol does not work. Appserver shows a key constraint error for Notification objects for the "ESM28Q" (and "ESM28Q_INFO") protocol, where Appserver attempts to store Notifications (generated from Task objects) with identical scheduledTime (and other fields). 

The duplicate tasks scheduled times (e.g., `2026-01-08T08:26:00Z` appearing multiple times) for the `ESM28Q` protocol, despite the distinct `repeatQuestionnaire` offsets, can be explained by the interaction between the `SimpleRepeatProtocolHandler` and `SimpleRepeatQuestionnaireHandler`.

### Root Cause Analysis

The schedule generation follows a two-stage process for "Repeat" protocols:

1.  **Reference Timestamp Generation (`SimpleRepeatProtocolHandler`)**:
    This handler generates a list of "base" timestamps (called `referenceTimestamps`) based on the `repeatProtocol` configuration. For instance, if the protocol repeats daily, it generates one timestamp for each day.

2.  **Task Generation (`SimpleRepeatQuestionnaireHandler`)**:
    This handler takes the list of `referenceTimestamps` and, for **each** one, applies the list of `unitsFromZero` from the `repeatQuestionnaire` configuration.

### Why Duplicates Occur

The duplicates happen when multiple `referenceTimestamps` result in the same `taskTime` after the offsets are applied.

In your specific configuration:
- `repeatQuestionnaire.unit` is set to `min` (minutes).
- `unitsFromZero` contains values like `2006`, `2156`, etc.

If the `repeatProtocol` (which governs the base `referenceTimestamps`) is set to a frequency that is **smaller** than the spread of your offsets, overlaps are inevitable.

**Example Scenario occurring in ESM28Q protocol:**
- If `repeatProtocol` is set to `1 day` (1440 minutes).
- `referenceTimestamp[0]` = `2026-01-07T08:26:00Z`.
- `referenceTimestamp[1]` = `2026-01-08T08:26:00Z`.
- An offset of `2006 minutes` applied to `referenceTimestamp[0]` results in `2026-01-08T17:52:00Z`.
- However, if the `repeatProtocol` or `referenceTimestamp` logic results in overlapping windows (for example, if multiple base timestamps are generated close together), or if the offsets are larger than the interval between reference points, the same absolute time will be calculated multiple times.

Specifically, in your logs, the timestamp `2026-01-08T08:26:00Z` repeats because:
1.  It is likely the **start time** (Reference Timestamp) for one of the days.
2.  The offset calculation `taskTime = timeCalculatorService.advanceRepeat(referenceTimestamp, timePeriod, timezone)` in `SimpleRepeatQuestionnaireHandler.java` (line 63) is producing that exact same instant from a **different** reference timestamp and a **different** offset.

### Solution
This PR introduces code to deduplicate Task objects using the _user_, _name_ and _timestamp_ fields prior to storage in the database, thereby defending against the edge-case where repeatProtocol and repeatQuestionnaire interaction schedule the same Tasks multiple times on the same moment in time. 
