### PR TITLE
Fix migration bugs and restore schedule generation

### DIFF
--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/resource/FcmNotificationResource.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/resource/FcmNotificationResource.kt
@@ -103,7 +103,7 @@ class FcmNotificationResource @Inject constructor(
     }
 
     @GET
-    @Path("$MESSAGING_NOTIFICATION_PATH/filter")
+    @Path("$MESSAGING_NOTIFICATION_PATH/filtered")
     @Produces(APPLICATION_JSON)
     @Authenticated
     @NeedsPermission(Permission.PROJECT_READ)
@@ -239,7 +239,7 @@ class FcmNotificationResource @Inject constructor(
     fun addBatchNotifications(
         @Valid @PathParam("projectId") projectId: String,
         @Valid @PathParam("subjectId") subjectId: String,
-        @QueryParam("schedule") @DefaultValue("false") schedule: Boolean,
+        @QueryParam("schedule") @DefaultValue("true") schedule: Boolean,
         @Valid fcmNotification: FcmNotifications,
         @Suspended asyncResponse: AsyncResponse,
     ) {

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/resource/TaskStateEventResource.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/resource/TaskStateEventResource.kt
@@ -57,7 +57,7 @@ class TaskStateEventResource @Inject constructor(
     @Path("/$QUESTIONNAIRE_SCHEDULE/$TASK_ID/$QUESTIONNAIRE_STATE_EVENTS_PATH")
     @Produces(APPLICATION_JSON)
     @Authenticated
-    @NeedsPermission(Permission.SUBJECT_READ)
+    @NeedsPermission(Permission.SUBJECT_UPDATE)
     fun getTaskStateEventsByTaskId(
         @PathParam("taskId") taskId: Long,
         @Suspended asyncResponse: AsyncResponse,
@@ -73,7 +73,7 @@ class TaskStateEventResource @Inject constructor(
     @Path("/$PROJECTS_PATH/$PROJECT_ID/$USERS_PATH/$SUBJECT_ID/$QUESTIONNAIRE_SCHEDULE/$TASK_ID/$QUESTIONNAIRE_STATE_EVENTS_PATH")
     @Produces(APPLICATION_JSON)
     @Authenticated
-    @NeedsPermission(Permission.SUBJECT_READ, projectPathParam = "projectId", userPathParam = "subjectId")
+    @NeedsPermission(Permission.SUBJECT_UPDATE, projectPathParam = "projectId", userPathParam = "subjectId")
     fun getTaskStateEvents(
         @PathParam("projectId") projectId: String,
         @PathParam("subjectId") subjectId: String,

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/resource/UserResource.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/resource/UserResource.kt
@@ -86,7 +86,7 @@ class UserResource @Inject constructor(
             val token = tokenForCurrentRequest(asyncService, tokenProvider)
             authService.checkPermission(
                 Permission.SUBJECT_UPDATE,
-                EntityDetails(project = projectId, subject = token.subject),
+                EntityDetails(project = projectId, subject = fcmUserDto.subjectId),
                 token,
             )
             if (forceFcmToken) userService.checkFcmTokenExistsAndReplace(fcmUserDto)

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/ProjectService.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/ProjectService.kt
@@ -137,10 +137,7 @@ class ProjectService @Inject constructor(
      */
     suspend fun updateProject(projectDto: ProjectDto): ProjectDto {
         return projectRepository.updateEfficiently(projectDto).let { savedProject ->
-            println("Project updated successfully: $savedProject")
-            projectMapper.entityToDto(savedProject).also {
-                println("Sending: $it")
-            }
+            projectMapper.entityToDto(savedProject)
         }
     }
 

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/TaskService.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/TaskService.kt
@@ -28,6 +28,7 @@ import org.radarbase.appserver.jersey.repository.TaskRepository
 import org.radarbase.appserver.jersey.repository.UserRepository
 import org.radarbase.appserver.jersey.search.QuerySpecification
 import org.radarbase.appserver.jersey.utils.checkPresence
+import org.radarbase.jersey.exception.HttpNotFoundException
 import java.sql.Timestamp
 import java.time.Instant
 
@@ -146,7 +147,10 @@ class TaskService @Inject constructor(
         )
 
         if (doesntExists) {
-            "The Task ${oldTask.id} does not exist to set to state $state  Please Use add endpoint"
+            throw HttpNotFoundException(
+                "task_not_found",
+                "The Task ${oldTask.id} does not exist to set to state $state. Please Use add endpoint",
+            )
         }
 
         if (state == TaskState.COMPLETED) {

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/TaskService.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/TaskService.kt
@@ -145,7 +145,7 @@ class TaskService @Inject constructor(
             taskTimestamp,
         )
 
-        checkPresence(doesntExists, "task_not_found") {
+        if (doesntExists) {
             "The Task ${oldTask.id} does not exist to set to state $state  Please Use add endpoint"
         }
 

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/UserService.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/UserService.kt
@@ -29,6 +29,7 @@ import org.radarbase.appserver.jersey.mapper.Mapper
 import org.radarbase.appserver.jersey.mapper.UserMapper
 import org.radarbase.appserver.jersey.repository.ProjectRepository
 import org.radarbase.appserver.jersey.repository.UserRepository
+import org.radarbase.appserver.jersey.service.questionnaire.schedule.QuestionnaireScheduleService
 import org.radarbase.appserver.jersey.utils.checkInvalidDetails
 import org.radarbase.appserver.jersey.utils.checkPresence
 import org.radarbase.jersey.exception.HttpNotFoundException
@@ -41,6 +42,7 @@ class UserService @Inject constructor(
     @Named(USER_MAPPER) val userMapper: Mapper<FcmUserDto, User>,
     val userRepository: UserRepository,
     val projectRepository: ProjectRepository,
+    val scheduleService: QuestionnaireScheduleService,
     config: AppserverConfig,
 ) {
     private val sendEmailNotifications: Boolean = config.email.enabled ?: false
@@ -217,6 +219,8 @@ class UserService @Inject constructor(
             userRepository.add(this)
         }
 
+        this.scheduleService.generateScheduleForUser(savedUser)
+
         return userMapper.entityToDto(savedUser)
     }
 
@@ -270,6 +274,10 @@ class UserService @Inject constructor(
             "user_not_found",
             "User with id ${user.id} not found.",
         )
+        // Generate schedule for user
+        if (user.attributes != userDto.attributes || user.timezone != userDto.timezone || user.enrolmentDate != userDto.enrolmentDate || user.language != userDto.language) {
+            this.scheduleService.generateScheduleForUser(savedUser)
+        }
 
         return userMapper.entityToDto(savedUser)
     }

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/questionnaire/schedule/QuestionnaireScheduleGeneratorService.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/questionnaire/schedule/QuestionnaireScheduleGeneratorService.kt
@@ -61,8 +61,8 @@ class QuestionnaireScheduleGeneratorService : ScheduleGeneratorService {
 
         val repeatQuestionnaire: RepeatQuestionnaire? = assessment.protocol?.repeatQuestionnaire
         val type = when {
-            repeatQuestionnaire?.dayOfWeekMap != null -> RepeatQuestionnaireHandlerType.DAYOFWEEKMAP
             repeatQuestionnaire?.randomUnitsFromZeroBetween != null -> RepeatQuestionnaireHandlerType.RANDOM
+            repeatQuestionnaire?.dayOfWeekMap != null -> RepeatQuestionnaireHandlerType.DAYOFWEEKMAP
             else -> RepeatQuestionnaireHandlerType.SIMPLE
         }
 

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/questionnaire/schedule/QuestionnaireScheduleService.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/questionnaire/schedule/QuestionnaireScheduleService.kt
@@ -31,12 +31,15 @@ import org.radarbase.appserver.jersey.search.TaskSpecificationsBuilder
 import org.radarbase.appserver.jersey.service.FcmNotificationService
 import org.radarbase.appserver.jersey.service.TaskService
 import org.radarbase.appserver.jersey.service.github.protocol.ProtocolGenerator
+import org.radarbase.appserver.jersey.service.scheduling.SchedulingService
 import org.radarbase.appserver.jersey.utils.checkInvalidDetails
 import org.radarbase.appserver.jersey.utils.checkPresence
 import org.radarbase.jersey.exception.HttpNotFoundException
+import org.radarbase.jersey.service.AsyncCoroutineService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.sql.Timestamp
+import java.time.Duration
 import java.time.Instant
 
 @Suppress("unused")
@@ -47,8 +50,19 @@ class QuestionnaireScheduleService @Inject constructor(
     private val projectRepository: ProjectRepository,
     private val taskService: TaskService,
     private val notificationService: FcmNotificationService,
+    schedulingService: SchedulingService,
+    asyncService: AsyncCoroutineService,
 ) {
     private val subjectScheduleMap: HashMap<String, Schedule> = hashMapOf()
+
+    private val cleanScheduleRef: SchedulingService.RepeatReference = schedulingService.repeat(
+        Duration.ofMillis(3_600_000),
+        Duration.ofMillis(5_000),
+    ) {
+        asyncService.runBlocking {
+            generateAllSchedules()
+        }
+    }
 
     suspend fun getTasksUsingProjectIdAndSubjectId(projectId: String, subjectId: String): List<Task> {
         return getTasksForUser(subjectAndProjectExistsElseThrow(subjectId, projectId))
@@ -66,8 +80,8 @@ class QuestionnaireScheduleService @Inject constructor(
     }
 
     suspend fun getTasksForDateUsingProjectIdAndSubjectId(
-        subjectId: String,
         projectId: String,
+        subjectId: String,
         startTime: Instant,
         endTime: Instant,
     ): List<Task> {
@@ -163,6 +177,15 @@ class QuestionnaireScheduleService @Inject constructor(
         saveTasksAndNotifications(user, listOf(assessmentSchedule))
 
         return schedule
+    }
+
+    suspend fun generateAllSchedules() {
+        logger.info("Generating all schedules")
+        userRepository.findAll().also { users: List<User> ->
+            users.forEach {
+                generateScheduleForUser(it)
+            }
+        }
     }
 
     fun getScheduleForSubject(subjectId: String): Schedule {

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/questionnaire/schedule/QuestionnaireScheduleService.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/questionnaire/schedule/QuestionnaireScheduleService.kt
@@ -50,7 +50,7 @@ class QuestionnaireScheduleService @Inject constructor(
 ) {
     private val subjectScheduleMap: HashMap<String, Schedule> = hashMapOf()
 
-    suspend fun getTasksUsingProjectIdAndSubjectId(subjectId: String, projectId: String): List<Task> {
+    suspend fun getTasksUsingProjectIdAndSubjectId(projectId: String, subjectId: String): List<Task> {
         return getTasksForUser(subjectAndProjectExistsElseThrow(subjectId, projectId))
     }
 

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/transmitter/EmailTransmitter.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/transmitter/EmailTransmitter.kt
@@ -42,6 +42,7 @@ class EmailTransmitter(
                     "Could not transmit a notification via email because subject {} has no email address",
                     notification.user?.subjectId,
                 )
+                return
             }
             try {
                 logger.info("Sending email to {}", to)

--- a/microservices/cloud-messaging-service/src/main/kotlin/org/radarbase/appserver/microservices/cloud/messaging/api/FcmNotificationResource.kt
+++ b/microservices/cloud-messaging-service/src/main/kotlin/org/radarbase/appserver/microservices/cloud/messaging/api/FcmNotificationResource.kt
@@ -86,7 +86,7 @@ class FcmNotificationResource @Inject constructor(
     }
 
     @GET
-    @Path("$MESSAGING_NOTIFICATION_PATH/filter")
+    @Path("$MESSAGING_NOTIFICATION_PATH/filtered")
     @Produces(APPLICATION_JSON)
     fun getFilteredNotifications(
         @Valid @QueryParam("type") type: String?,
@@ -202,7 +202,7 @@ class FcmNotificationResource @Inject constructor(
     fun addBatchNotifications(
         @Valid @PathParam("projectId") projectId: String,
         @Valid @PathParam("subjectId") subjectId: String,
-        @QueryParam("schedule") @DefaultValue("false") schedule: Boolean,
+        @QueryParam("schedule") @DefaultValue("true") schedule: Boolean,
         @Valid fcmNotification: FcmNotifications,
         @Suspended asyncResponse: AsyncResponse,
     ) {

--- a/microservices/cloud-messaging-service/src/main/kotlin/org/radarbase/appserver/microservices/cloud/messaging/service/transmitter/EmailTransmitter.kt
+++ b/microservices/cloud-messaging-service/src/main/kotlin/org/radarbase/appserver/microservices/cloud/messaging/service/transmitter/EmailTransmitter.kt
@@ -56,6 +56,7 @@ class EmailTransmitter(
                     "Could not transmit a notification via email because subject {} has no email address",
                     user.subjectId
                 )
+                return
             }
 
             try {

--- a/microservices/core/src/main/kotlin/org/radarbase/appserver/microservices/core/service/questionnaire.schedule/QuestionnaireScheduleGeneratorService.kt
+++ b/microservices/core/src/main/kotlin/org/radarbase/appserver/microservices/core/service/questionnaire.schedule/QuestionnaireScheduleGeneratorService.kt
@@ -61,8 +61,8 @@ class QuestionnaireScheduleGeneratorService : ScheduleGeneratorService {
 
         val repeatQuestionnaire: RepeatQuestionnaire? = assessment.protocol?.repeatQuestionnaire
         val type = when {
-            repeatQuestionnaire?.dayOfWeekMap != null -> RepeatQuestionnaireHandlerType.DAYOFWEEKMAP
             repeatQuestionnaire?.randomUnitsFromZeroBetween != null -> RepeatQuestionnaireHandlerType.RANDOM
+            repeatQuestionnaire?.dayOfWeekMap != null -> RepeatQuestionnaireHandlerType.DAYOFWEEKMAP
             else -> RepeatQuestionnaireHandlerType.SIMPLE
         }
 

--- a/microservices/gateway-service/src/main/kotlin/org/radarbase/appserver/microservices/gateway/api/GatewayResource.kt
+++ b/microservices/gateway-service/src/main/kotlin/org/radarbase/appserver/microservices/gateway/api/GatewayResource.kt
@@ -427,7 +427,7 @@ class GatewayResource @Inject constructor(
             val token = tokenForCurrentRequest(asyncService, tokenProvider)
             authService.checkPermission(
                 Permission.SUBJECT_UPDATE,
-                EntityDetails(project = projectId, subject = token.subject),
+                EntityDetails(project = projectId, subject = fcmUserDto.subjectId),
                 token,
             )
 
@@ -1174,7 +1174,7 @@ class GatewayResource @Inject constructor(
     @Path("$MESSAGING_DATA_PATH/{id}")
     @Produces(APPLICATION_JSON)
     @Authenticated
-    @NeedsPermission(Permission.SUBJECT_READ)G
+    @NeedsPermission(Permission.SUBJECT_READ)
     fun getDataMessageUsingId(
         @PathParam("id") id: Long,
         @Suspended asyncResponse: AsyncResponse,

--- a/microservices/gateway-service/src/main/kotlin/org/radarbase/appserver/microservices/gateway/api/GatewayResource.kt
+++ b/microservices/gateway-service/src/main/kotlin/org/radarbase/appserver/microservices/gateway/api/GatewayResource.kt
@@ -652,7 +652,7 @@ class GatewayResource @Inject constructor(
     @Path("/$QUESTIONNAIRE_SCHEDULE/$TASK_ID/$QUESTIONNAIRE_STATE_EVENTS_PATH")
     @Produces(APPLICATION_JSON)
     @Authenticated
-    @NeedsPermission(Permission.SUBJECT_READ)
+    @NeedsPermission(Permission.SUBJECT_UPDATE)
     fun getTaskStateEventsByTaskId(
         @PathParam("taskId") taskId: Long,
         @Suspended asyncResponse: AsyncResponse,
@@ -668,7 +668,7 @@ class GatewayResource @Inject constructor(
     @Path("/$PROJECTS_PATH/$PROJECT_ID/$USERS_PATH/$SUBJECT_ID/$QUESTIONNAIRE_SCHEDULE/$TASK_ID/$QUESTIONNAIRE_STATE_EVENTS_PATH")
     @Produces(APPLICATION_JSON)
     @Authenticated
-    @NeedsPermission(Permission.SUBJECT_READ, projectPathParam = "projectId", userPathParam = "subjectId")
+    @NeedsPermission(Permission.SUBJECT_UPDATE, projectPathParam = "projectId", userPathParam = "subjectId")
     fun getTaskStateEvents(
         @PathParam("projectId") projectId: String,
         @PathParam("subjectId") subjectId: String,

--- a/microservices/project-service/src/main/kotlin/org/radarbase/appserver/microservices/project/service/ProjectService.kt
+++ b/microservices/project-service/src/main/kotlin/org/radarbase/appserver/microservices/project/service/ProjectService.kt
@@ -136,10 +136,7 @@ class ProjectService @Inject constructor(
      */
     suspend fun updateProject(projectDto: ProjectDto): ProjectDto {
         return projectRepository.updateEfficiently(projectDto).let { savedProject ->
-            println("Project updated successfully: $savedProject")
-            projectMapper.entityToDto(savedProject).also {
-                println("Sending: $it")
-            }
+            projectMapper.entityToDto(savedProject)
         }
     }
 

--- a/microservices/task-service/src/main/kotlin/org/radarbase/appserver/microservices/task/service/TaskServiceImpl.kt
+++ b/microservices/task-service/src/main/kotlin/org/radarbase/appserver/microservices/task/service/TaskServiceImpl.kt
@@ -36,6 +36,7 @@ import org.radarbase.appserver.microservices.core.utils.Const.USER_MAPPER
 import org.radarbase.appserver.microservices.core.utils.checkPresence
 import org.radarbase.appserver.microservices.core.utils.requireNotNullField
 import org.radarbase.appserver.microservices.task.config.TaskServiceConfig
+import org.radarbase.jersey.exception.HttpNotFoundException
 import java.sql.Timestamp
 import java.time.Instant
 
@@ -169,7 +170,10 @@ class TaskServiceImpl @Inject constructor(
         )
 
         if (doesntExists) {
-            "The Task ${oldTask.id} does not exist to set to state $state  Please Use add endpoint"
+            throw HttpNotFoundException(
+                "task_not_found",
+                "The Task ${oldTask.id} does not exist to set to state $state. Please Use add endpoint",
+            )
         }
 
         if (state == TaskState.COMPLETED) {

--- a/microservices/task-service/src/main/kotlin/org/radarbase/appserver/microservices/task/service/TaskServiceImpl.kt
+++ b/microservices/task-service/src/main/kotlin/org/radarbase/appserver/microservices/task/service/TaskServiceImpl.kt
@@ -168,7 +168,7 @@ class TaskServiceImpl @Inject constructor(
             taskTimestamp,
         )
 
-        checkPresence(doesntExists, "task_not_found") {
+        if (doesntExists) {
             "The Task ${oldTask.id} does not exist to set to state $state  Please Use add endpoint"
         }
 

--- a/microservices/task-service/src/main/kotlin/org/radarbase/appserver/microservices/task/service/questionnaire/schedule/QuestionnaireScheduleService.kt
+++ b/microservices/task-service/src/main/kotlin/org/radarbase/appserver/microservices/task/service/questionnaire/schedule/QuestionnaireScheduleService.kt
@@ -85,7 +85,7 @@ class QuestionnaireScheduleService @Inject constructor(
         }
     }
 
-    suspend fun getTasksUsingProjectIdAndSubjectId(subjectId: String, projectId: String): List<Task> {
+    suspend fun getTasksUsingProjectIdAndSubjectId(projectId: String, subjectId: String): List<Task> {
         return getTasksForUser(subjectAndProjectExistsElseThrow(subjectId, projectId))
     }
 

--- a/microservices/task-service/src/main/kotlin/org/radarbase/appserver/microservices/task/service/questionnaire/schedule/QuestionnaireScheduleService.kt
+++ b/microservices/task-service/src/main/kotlin/org/radarbase/appserver/microservices/task/service/questionnaire/schedule/QuestionnaireScheduleService.kt
@@ -101,8 +101,8 @@ class QuestionnaireScheduleService @Inject constructor(
     }
 
     suspend fun getTasksForDateUsingProjectIdAndSubjectId(
-        subjectId: String,
         projectId: String,
+        subjectId: String,
         startTime: Instant,
         endTime: Instant,
     ): List<Task> {

--- a/microservices/user-service/src/main/kotlin/org/radarbase/appserver/microservices/user/service/UserServiceImpl.kt
+++ b/microservices/user-service/src/main/kotlin/org/radarbase/appserver/microservices/user/service/UserServiceImpl.kt
@@ -18,7 +18,11 @@ package org.radarbase.appserver.microservices.user.service
 
 import jakarta.inject.Inject
 import jakarta.inject.Named
+import jakarta.ws.rs.core.Response
+import kotlinx.serialization.json.Json
 import org.radarbase.appserver.microservices.contract.calls.ProjectServiceContract
+import org.radarbase.appserver.microservices.contract.calls.QuestionnaireScheduleContract
+import org.radarbase.appserver.microservices.contract.exception.ProxyResponseException
 import org.radarbase.appserver.microservices.contract.utils.Utils.deserializeDtoFromContract
 import org.radarbase.appserver.microservices.core.dto.ProjectDto
 import org.radarbase.appserver.microservices.core.dto.fcm.FcmUserDto
@@ -49,6 +53,9 @@ class UserServiceImpl @Inject constructor(
 ) : UserService {
     private val sendEmailNotifications: Boolean = config.email.enabled
     private val projectServiceUrl = config.contract.project
+    private val taskServiceUrl = config.contract.task
+
+    private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
 
     /**
      * Retrieves all users associated with the projects.
@@ -237,6 +244,7 @@ class UserServiceImpl @Inject constructor(
         }.run {
             userRepository.add(this)
         }
+        generateScheduleUsingProjectIdAndSubjectId(savedUser.projectId, savedUser.subjectId)
 
         return userMapper.entityToDto(savedUser)
     }
@@ -293,6 +301,14 @@ class UserServiceImpl @Inject constructor(
             "user_not_found",
             "User with id ${user.id} not found.",
         )
+        // Generate schedule for user
+        if (user.attributes != userDto.attributes ||
+            user.timezone !=
+            userDto.timezone ||
+            user.enrolmentDate?.equals(userDto.enrolmentDate) != true  ||
+            user.language != userDto.language) {
+            generateScheduleUsingProjectIdAndSubjectId(updatedUser.projectId, updatedUser.subjectId)
+        }
 
         return userMapper.entityToDto(updatedUser)
     }
@@ -342,6 +358,21 @@ class UserServiceImpl @Inject constructor(
         }
 
         this.userRepository.delete(user)
+    }
+
+    private suspend fun generateScheduleUsingProjectIdAndSubjectId(projectId: String?, subjectId: String?) {
+        return QuestionnaireScheduleContract.generateScheduleUsingProjectIdAndSubjectId(
+            requireNotNull(projectId) { "User's Project id must not be null" },
+            requireNotNull(subjectId) { "Subject id must not be null" },
+            taskServiceUrl
+        ).let {
+            if (it.status !in 200 .. 299) {
+                throw ProxyResponseException(
+                    Response.Status.fromStatusCode(it.status),
+                    it.body?.decodeToString() ?: "Upstream sent an incorrect response",
+                )
+            }
+        }
     }
 
     companion object {


### PR DESCRIPTION
Fixes several issues found while verifying the Jersey migration against the original appserver: 
- swapped projectId/subjectId arguments in the questionnaire schedule endpoints
-  a task not-found check that never threw
-  a wrong repeat-questionnaire handler order
-  and a few API compatibility fixes 

This PR also restores schedule generation on user creation and the hourly schedule generation task (undoing [#540](https://github.com/RADAR-base/RADAR-Appserver/pull/540) and [#541](https://github.com/RADAR-base/RADAR-Appserver/pull/541) for the Jersey version), now built on the SchedulingService.