### PR TITLE
Make Quartz DB-backed and compatible with legacy-scheduled jobs

### DIFF
--- a/.github/workflows/jersey-main.yml
+++ b/.github/workflows/jersey-main.yml
@@ -1,7 +1,7 @@
 name: CI jersey-main
 on:
   push:
-    branches: [ master, dev ]
+    branches: [ master, dev, db-quartz ]
   pull_request:
     branches: [ master, dev ]
 

--- a/.github/workflows/jersey-main.yml
+++ b/.github/workflows/jersey-main.yml
@@ -4,7 +4,7 @@ on:
     branches: [ master, dev, db-quartz ]
   pull_request:
     branches: [ master, dev ]
-
+#
 env:
   REGISTRY: ghcr.io
   REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/jersey-main.yml
+++ b/.github/workflows/jersey-main.yml
@@ -1,7 +1,7 @@
 name: CI jersey-main
 on:
   push:
-    branches: [ master, dev, db-quartz ]
+    branches: [ master, dev ]
   pull_request:
     branches: [ master, dev ]
 #

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/config/SchedulerConfig.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/config/SchedulerConfig.kt
@@ -19,4 +19,9 @@ package org.radarbase.appserver.jersey.config
 data class SchedulerConfig(
     val coroutineDispatcher: String = "io",
     val coroutineJob: String = "supervisor-job",
+    val instanceName: String = "quartzScheduler",
+    val threadCount: Int = 5,
+    val tablePrefix: String = "QRTZ_",
+    val driverDelegateClass: String = "org.quartz.impl.jdbcjobstore.PostgreSQLDelegate",
+    val misfireThreshold: Long = 60_000,
 )

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/dto/ProjectDto.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/dto/ProjectDto.kt
@@ -43,7 +43,7 @@ data class ProjectDto(
 
     @field:JsonFormat(
         shape = JsonFormat.Shape.STRING,
-        pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+        pattern = "yyyy-MM-dd'T'HH:mm:ss[.SSS]XXX",
         timezone = "UTC",
     )
     @Serializable(with = InstantSerializer::class)
@@ -51,7 +51,7 @@ data class ProjectDto(
 
     @field:JsonFormat(
         shape = JsonFormat.Shape.STRING,
-        pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+        pattern = "yyyy-MM-dd'T'HH:mm:ss[.SSS]XXX",
         timezone = "UTC",
     )
     @Serializable(with = InstantSerializer::class)

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/dto/fcm/FcmDataMessageDto.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/dto/fcm/FcmDataMessageDto.kt
@@ -29,7 +29,7 @@ class FcmDataMessageDto(dataMessageEntity: DataMessage? = null) {
 
     @field:JsonFormat(
         shape = JsonFormat.Shape.STRING,
-        pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+        pattern = "yyyy-MM-dd'T'HH:mm:ss[.SSS]XXX",
         timezone = "UTC",
     )
     var scheduledTime: @NotNull Instant? = dataMessageEntity?.scheduledTime
@@ -63,14 +63,14 @@ class FcmDataMessageDto(dataMessageEntity: DataMessage? = null) {
 
     @field:JsonFormat(
         shape = JsonFormat.Shape.STRING,
-        pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+        pattern = "yyyy-MM-dd'T'HH:mm:ss[.SSS]XXX",
         timezone = "UTC",
     )
     var createdAt: Instant? = dataMessageEntity?.createdAt?.toInstant()
 
     @field:JsonFormat(
         shape = JsonFormat.Shape.STRING,
-        pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+        pattern = "yyyy-MM-dd'T'HH:mm:ss[.SSS]XXX",
         timezone = "UTC",
     )
     var updatedAt: Instant? = dataMessageEntity?.updatedAt?.toInstant()

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/dto/fcm/FcmUserDto.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/dto/fcm/FcmUserDto.kt
@@ -62,7 +62,7 @@ data class FcmUserDto(
 
     @field:JsonFormat(
         shape = JsonFormat.Shape.STRING,
-        pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+        pattern = "yyyy-MM-dd'T'HH:mm:ss[.SSS]XXX",
         timezone = "UTC",
     )
     @Serializable(with = InstantSerializer::class)
@@ -70,7 +70,7 @@ data class FcmUserDto(
 
     @field:JsonFormat(
         shape = JsonFormat.Shape.STRING,
-        pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+        pattern = "yyyy-MM-dd'T'HH:mm:ss[.SSS]XXX",
         timezone = "UTC",
     )
     @Serializable(with = InstantSerializer::class)
@@ -79,7 +79,7 @@ data class FcmUserDto(
     @field:NotNull
     @field:JsonFormat(
         shape = JsonFormat.Shape.STRING,
-        pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+        pattern = "yyyy-MM-dd'T'HH:mm:ss[.SSS]XXX",
         timezone = "UTC",
     )
     @Serializable(with = InstantSerializer::class)

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/entity/DataMessage.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/entity/DataMessage.kt
@@ -24,6 +24,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
 import jakarta.persistence.Inheritance
 import jakarta.persistence.InheritanceType
+import jakarta.persistence.JoinColumn
 import jakarta.persistence.MapKeyColumn
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
@@ -54,7 +55,10 @@ import java.time.Instant
 class DataMessage : Message() {
     @Nullable
     @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name = "data_message_map")
+    @CollectionTable(
+        name = "data_message_map",
+        joinColumns = [JoinColumn(name = "data_message_id")],
+    )
     @MapKeyColumn(name = "data_message_key", nullable = true)
     @Column(name = "data_message_value")
     var dataMap: MutableMap<String?, String?>? = null

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/entity/Notification.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/entity/Notification.kt
@@ -17,6 +17,7 @@
 package org.radarbase.appserver.jersey.entity
 
 import jakarta.annotation.Nullable
+import jakarta.persistence.CollectionTable
 import jakarta.persistence.Column
 import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
@@ -108,6 +109,7 @@ class Notification : Message() {
 
     @Nullable
     @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "notification_additional_data")
     @MapKeyColumn(name = "additional_key", nullable = true)
     @Column(name = "additional_value")
     var additionalData: Map<String?, String?>? = null

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/factory/quartz/QuartzSchedulerFactory.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/factory/quartz/QuartzSchedulerFactory.kt
@@ -22,13 +22,16 @@ import org.glassfish.jersey.internal.inject.DisposableSupplier
 import org.quartz.Scheduler
 import org.quartz.SchedulerFactory
 import org.quartz.impl.StdSchedulerFactory
+import org.radarbase.appserver.jersey.config.AppserverConfig
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.util.Properties
 
 class QuartzSchedulerFactory @Inject constructor(
     private val serviceLocator: ServiceLocator,
+    appserverConfig: AppserverConfig,
 ) : DisposableSupplier<Scheduler> {
-    val schedulerFactory: SchedulerFactory = StdSchedulerFactory()
+    val schedulerFactory: SchedulerFactory = StdSchedulerFactory(buildQuartzProperties(appserverConfig))
     var scheduler: Scheduler? = null
 
     override fun get(): Scheduler {
@@ -53,5 +56,30 @@ class QuartzSchedulerFactory @Inject constructor(
 
     companion object {
         private val logger: Logger = LoggerFactory.getLogger(QuartzSchedulerFactory::class.java)
+
+        private const val DATA_SOURCE_NAME = "appserverDS"
+
+        private fun buildQuartzProperties(config: AppserverConfig): Properties {
+            val db = config.db
+            val quartz = config.quartz
+            return Properties().apply {
+                setProperty("org.quartz.scheduler.instanceName", quartz.instanceName)
+                setProperty("org.quartz.scheduler.instanceId", "AUTO")
+                setProperty("org.quartz.threadPool.class", "org.quartz.simpl.SimpleThreadPool")
+                setProperty("org.quartz.threadPool.threadCount", quartz.threadCount.toString())
+                setProperty("org.quartz.jobStore.class", "org.quartz.impl.jdbcjobstore.JobStoreTX")
+                setProperty("org.quartz.jobStore.driverDelegateClass", quartz.driverDelegateClass)
+                setProperty("org.quartz.jobStore.tablePrefix", quartz.tablePrefix)
+                setProperty("org.quartz.jobStore.dataSource", DATA_SOURCE_NAME)
+                setProperty("org.quartz.jobStore.misfireThreshold", quartz.misfireThreshold.toString())
+                val prefix = "org.quartz.dataSource.$DATA_SOURCE_NAME"
+                setProperty("$prefix.provider", "hikaricp")
+                setProperty("$prefix.driver", db.jdbcDriver)
+                setProperty("$prefix.URL", db.jdbcUrl)
+                setProperty("$prefix.user", db.username)
+                setProperty("$prefix.password", db.password)
+                setProperty("$prefix.maxConnections", (quartz.threadCount + 2).toString())
+            }
+        }
     }
 }

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/questionnaire/schedule/MessageSchedulerService.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/jersey/service/questionnaire/schedule/MessageSchedulerService.kt
@@ -30,7 +30,7 @@ import org.radarbase.appserver.jersey.entity.Message
 import org.radarbase.appserver.jersey.entity.Notification
 import org.radarbase.appserver.jersey.entity.User
 import org.radarbase.appserver.jersey.fcm.downstream.FcmSender
-import org.radarbase.appserver.jersey.service.quartz.MessageJob
+import org.radarbase.appserver.service.scheduler.quartz.MessageJob
 import org.radarbase.appserver.jersey.service.quartz.MessageType
 import org.radarbase.appserver.jersey.service.quartz.QuartzNamingStrategy
 import org.radarbase.appserver.jersey.service.quartz.SchedulerService

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/service/scheduler/quartz/MessageJob.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/service/scheduler/quartz/MessageJob.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.radarbase.appserver.jersey.service.quartz
+package org.radarbase.appserver.service.scheduler.quartz
 
 import jakarta.inject.Inject
 import org.jvnet.hk2.annotations.Optional
@@ -22,6 +22,7 @@ import org.quartz.Job
 import org.quartz.JobExecutionContext
 import org.quartz.JobExecutionException
 import org.radarbase.appserver.jersey.config.AppserverConfig
+import org.radarbase.appserver.jersey.service.quartz.MessageType
 import org.radarbase.appserver.jersey.exception.FcmMessageTransmitException
 import org.radarbase.appserver.jersey.exception.MessageTransmitException
 import org.radarbase.appserver.jersey.service.FcmDataMessageService
@@ -34,6 +35,14 @@ import org.slf4j.LoggerFactory
 
 /**
  * A [Job] that sends notification/message to the device or email when executed.
+ *
+ * NOTE: This class intentionally lives in the legacy Spring package
+ * `org.radarbase.appserver.service.scheduler.quartz` (not under `...jersey.*`).
+ * Quartz's JDBC job store persists the fully-qualified job class name in
+ * QRTZ_JOB_DETAILS.JOB_CLASS_NAME and resolves it via Class.forName(...) when firing a
+ * job. Jobs scheduled by the legacy Spring app server stored THIS exact name, so keeping
+ * the package identical lets those pending jobs continue to fire under the Jersey app.
+ *
  */
 class MessageJob @Inject constructor(
     private val notificationTransmitter: NotificationTransmitter,

--- a/appserver-jersey/src/main/kotlin/org/radarbase/appserver/service/scheduler/quartz/MessageJob.kt
+++ b/appserver-jersey/src/main/kotlin/org/radarbase/appserver/service/scheduler/quartz/MessageJob.kt
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory
 /**
  * A [Job] that sends notification/message to the device or email when executed.
  *
- * NOTE: This class intentionally lives in the legacy Spring package
+ * NOTE: This class intentionally retains the legacy Spring package
  * `org.radarbase.appserver.service.scheduler.quartz` (not under `...jersey.*`).
  * Quartz's JDBC job store persists the fully-qualified job class name in
  * QRTZ_JOB_DETAILS.JOB_CLASS_NAME and resolves it via Class.forName(...) when firing a

--- a/appserver-jersey/src/main/resources/appserver.yml
+++ b/appserver-jersey/src/main/resources/appserver.yml
@@ -63,6 +63,17 @@ quartz:
   # Defaults to 'supervisor-job' if not provided.
   coroutineJob: supervisor-job
 
+  # Must match SCHED_NAME in the existing QRTZ_* tables ("quartzScheduler" is Spring
+  # Boot's default) so jobs scheduled by the legacy app server keep firing.
+  instanceName: quartzScheduler
+  # Number of worker threads for firing jobs.
+  threadCount: 5
+  # Prefix of the Quartz tables.
+  tablePrefix: QRTZ_
+  driverDelegateClass: org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
+  # Misfire threshold in milliseconds.
+  misfireThreshold: 60000
+
 protocol:
   githubProtocolRepo: RADAR-base/RADAR-aRMT-protocols
   protocolFileName: protocol.json

--- a/appserver-jersey/src/main/resources/appserver.yml
+++ b/appserver-jersey/src/main/resources/appserver.yml
@@ -10,7 +10,7 @@ server:
 
 # Authentication configuration.
 auth:
-  managementPortalUrl: http://localhost:8081/managementportal
+  managementPortalUrl: http://stage.radar-base.net/managementportal
   resourceName: res_AppServer
 
 db:
@@ -24,6 +24,10 @@ db:
   #    jakarta.persistence.schema-generation.database.action: drop-and-create
   additionalProperties:
     hibernate.hbm2ddl.auto: validate
+    # Hibernate 6 defaults to per-entity sequences (<table>_seq). The existing
+    # schema (and the legacy Spring Boot app) use a single shared
+    # `hibernate_sequence`, so restore the pre-6 naming to match the DB.
+    hibernate.id.db_structure_naming_strategy: legacy
   #    hibernate.show_sql: true
   #    hibernate.format_sql: true
   jdbcDriver: org.postgresql.Driver

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -15,7 +15,7 @@ object Versions {
     const val springVersion = "6.0.6"
     const val radarSpringAuthVersion = "1.2.1"
     const val guavaVersion = "32.1.3-jre"
-    const val radarJerseyVersion = "0.12.7-SNAPSHOT"
+    const val radarJerseyVersion = "0.12.7"
     const val jacksonKotlinVersion = "2.15.4"
     const val ktorVersion = "2.3.13"
     const val coroutinesVersion = "1.10.1"


### PR DESCRIPTION
While testing the jersey migration I noticed replacing the legacy spring Appserver never touched the existing quartz scheduler rows. This PR aligns this so previously scheduled notifications now fire correctly under jersey. Also adds configurable Quartz settings (thread count, table prefix, delegate, misfire threshold).